### PR TITLE
Add `get_hosts` endpoint to TMI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,11 @@ path = "examples/get_channel_status.rs"
 required-features = ["twitch_oauth2/reqwest_client", "reqwest_client"]
 
 [[example]]
+name = "get_hosts"
+path = "examples/get_hosts.rs"
+required-features = ["surf_client"]
+
+[[example]]
 name = "get_moderation"
 path = "examples/get_moderation.rs"
 required-features = ["twitch_oauth2/surf_client", "surf_client"]

--- a/examples/get_hosts.rs
+++ b/examples/get_hosts.rs
@@ -1,0 +1,62 @@
+use twitch_api2::tmi::{Host, HostsRequestId};
+use twitch_api2::TMIClient;
+
+#[tokio::main]
+async fn main() {
+    dotenv::dotenv().ok();
+
+    let mut args = std::env::args().skip(1);
+    let channel_id = if let Some(Ok(id)) = args.next().map(|s| s.parse::<u64>()) {
+        id
+    } else if let Ok(Ok(id)) = std::env::var("TWITCH_CHANNEL_ID").map(|s| s.parse::<u64>()) {
+        id
+    } else {
+        eprintln!(
+            "Please provide a channel ID as either the first argument \
+			or stored in the `TWITCH_CHANNEL_ID` environment variable"
+        );
+        return;
+    };
+
+    let client = TMIClient::<'_, surf::Client>::new();
+
+    let response = client
+        .get_hosts(true, HostsRequestId::Host(channel_id))
+        .await
+        .expect("`HostsRequest::Host` failed");
+
+    match response
+        .hosts
+        .first()
+        .expect("`get_hosts` should have returned exactly one record")
+    {
+        Host {
+            target_id: Some(target_id),
+            target_display_name: Some(target_name),
+            host_display_name: Some(host_name),
+            ..
+        } => {
+            println!("{} is hosting: {:#?}", host_name, response.hosts.first());
+
+            let response = client
+                .get_hosts(true, HostsRequestId::Target(*target_id))
+                .await
+                .expect("`HostsRequest::Target` failed");
+
+            println!("Also hosting {}:", target_name);
+
+            for host in response.hosts {
+                println!(
+                    "  {}",
+                    host.host_display_name.unwrap_or_else(|| "[unknown]".into())
+                );
+            }
+        }
+        Host {
+            target_id: None,
+            host_display_name: Some(name),
+            ..
+        } => println!("{} is not hosting anyone.", name),
+        _ => println!("Couldn't find requested host."),
+    }
+}

--- a/src/tmi/mod.rs
+++ b/src/tmi/mod.rs
@@ -86,6 +86,46 @@ impl<'a, C: crate::HttpClient<'a>> TMIClient<'a, C> {
             .map_err(|e| RequestError::Utf8Error(req.body().clone(), e))?;
         serde_json::from_str(text).map_err(Into::into)
     }
+
+    /// Get the broadcaster that a given channel is hosting, or
+    /// the list of channels hosting a given target broadcaster.
+    ///
+    /// # Notes
+    /// This endpoint requires `host={id}` XOR `target={id}` in the query
+    /// (providing both will result in an error, therefore this function takes
+    /// a [HostsRequestId] enum).
+    pub async fn get_hosts(
+        &'a self,
+        include_logins: bool,
+        channel_id: HostsRequestId,
+    ) -> Result<GetHosts, RequestError<<C as crate::HttpClient<'a>>::Error>>
+    {
+        let url = format!(
+            "{}{}{}{}",
+            crate::TWITCH_TMI_URL,
+            "hosts?",
+            if include_logins {
+                "include_logins=1&"
+            } else {
+                ""
+            },
+            match channel_id {
+                HostsRequestId::Host(id) => format!("host={}", id),
+                HostsRequestId::Target(id) => format!("target={}", id),
+            }
+        );
+        let req = http::Request::builder()
+            .uri(url)
+            .body(Vec::with_capacity(0))?;
+        let req = self
+            .client
+            .req(req)
+            .await
+            .map_err(|e| RequestError::RequestError(Box::new(e)))?;
+        let text = std::str::from_utf8(&req.body())
+            .map_err(|e| RequestError::Utf8Error(req.body().clone(), e))?;
+        serde_json::from_str(text).map_err(Into::into)
+    }
 }
 
 /// Returned by TMI at `https://tmi.twitch.tv/group/user/{broadcaster}/chatters`
@@ -118,8 +158,50 @@ pub struct Chatters {
     pub viewers: Vec<Nickname>,
 }
 
+/// Possible options for a [TMIClient::get_hosts] request.
+#[derive(Debug)]
+pub enum HostsRequestId {
+    /// Request the broadcaster that a given channel is hosting.
+    Host(UserId),
+    /// Request a list of channels hosting a target broadcaster.
+    Target(UserId),
+}
+
+/// Returned by TMI at `https://tmi.twitch.tv/hosts`
+///
+/// See [TMIClient::get_hosts]
+#[derive(Debug, Serialize, Deserialize)]
+pub struct GetHosts {
+    /// List of host records. `len()` will be 1 if successfully requested for a
+    /// [HostsRequestId::Host], in which case `target_id` may be missing if the
+    /// channel is not hosting anyone.
+    pub hosts: Vec<Host>,
+}
+
+/// A host record returned by TMI at https://tmi.twitch.tv/hosts
+///
+/// See [TMIClient::get_hosts]
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Host {
+    /// User ID of the hosting channel
+    pub host_id: UserId,
+    /// User ID of the hosted channel. Will be missing if the given channel is not hosting anyone.
+    pub target_id: Option<UserId>,
+    /// Login of the hosting channel, if requested with `include_logins = true`
+    pub host_login: Option<Nickname>,
+    /// Login of the hosted channel, if requested with `include_logins = true`
+    pub target_login: Option<Nickname>,
+    /// Display name of the hosting channel, if requested with `include_logins = true`
+    pub host_display_name: Option<Nickname>,
+    /// Display name of the hosted channel, if requested with `include_logins = true`
+    pub target_display_name: Option<Nickname>,
+}
+
 /// Nickname
 pub type Nickname = String;
+
+/// User ID
+pub type UserId = u64; // TMI user ID's appear to still be ints, even though Helix uses strings.
 
 /// Errors for [TMIClient] requests
 #[derive(thiserror::Error, Debug, displaydoc::Display)]


### PR DESCRIPTION
Added support for the `get_hosts` endpoint of TMI, which can either get a list of hosts hosting a target channel, *or* get the channel that is being hosted by a given channel. Also added an example, which requires a host channel ID, then checks if any other channels are hosting the target. We could get the channel ID given a username using Helix, but that would then require an auth token.