### PR TITLE
Fix `user_name` actually being `display_name`

### DIFF
--- a/src/eventsub/channel/channel_points_custom_reward_redemption/add.rs
+++ b/src/eventsub/channel/channel_points_custom_reward_redemption/add.rs
@@ -44,7 +44,7 @@ pub struct ChannelPointsCustomRewardRedemptionAddV1Payload {
     /// The user input provided. Empty string if not provided.
     pub user_input: String,
     /// Display name of the user that redeemed the reward.
-    pub user_name: types::UserName,
+    pub user_name: types::DisplayName,
 }
 
 #[test]

--- a/src/eventsub/channel/channel_points_custom_reward_redemption/update.rs
+++ b/src/eventsub/channel/channel_points_custom_reward_redemption/update.rs
@@ -43,7 +43,7 @@ pub struct ChannelPointsCustomRewardRedemptionUpdateV1Payload {
     /// The user input provided. Empty string if not provided.
     pub user_input: String,
     /// Display name of the user that redeemed the reward.
-    pub user_name: types::UserName,
+    pub user_name: types::DisplayName,
 }
 
 #[test]

--- a/src/helix/bits/get_bits_leaderboard.rs
+++ b/src/helix/bits/get_bits_leaderboard.rs
@@ -110,7 +110,7 @@ pub struct LeaderboardUser {
     /// ID of the user (viewer) in the leaderboard entry.
     pub user_id: types::UserId,
     /// Display name corresponding to user_id.
-    pub user_name: types::UserName,
+    pub user_name: types::DisplayName,
 }
 
 impl helix::Request for GetBitsLeaderboardRequest {

--- a/src/helix/channels/get_channel_information.rs
+++ b/src/helix/channels/get_channel_information.rs
@@ -62,7 +62,7 @@ pub struct ChannelInformation {
     /// Twitch User ID of this channel owner
     pub broadcaster_id: types::UserId,
     /// Twitch user display name of this channel owner
-    pub broadcaster_name: types::UserName,
+    pub broadcaster_name: types::DisplayName,
     /// Current game ID being played on the channel
     pub game_id: types::CategoryId,
     /// Name of the game being played on the channel

--- a/src/helix/moderation/get_moderators.rs
+++ b/src/helix/moderation/get_moderators.rs
@@ -68,8 +68,6 @@ pub struct Moderator {
     /// Twitch says: `User ID of a user who has been banned.` but this seems wrong.
     pub user_id: types::UserId,
     /// Display name of moderator
-    ///
-    /// Twitch says: `Display name of a user who has been banned.` but this seems wrong.
     pub user_name: types::DisplayName,
 }
 

--- a/src/helix/points/get_custom_reward_redemption.rs
+++ b/src/helix/points/get_custom_reward_redemption.rs
@@ -84,7 +84,7 @@ pub struct CustomRewardRedemption {
     pub broadcaster_id: types::UserId,
 
     /// The display name of the broadcaster that the reward belongs to.
-    pub broadcaster_name: types::UserName,
+    pub broadcaster_name: types::DisplayName,
 
     /// The ID of the redemption.
     pub id: types::RedemptionId,
@@ -93,7 +93,7 @@ pub struct CustomRewardRedemption {
     pub user_id: types::UserId,
 
     /// The display name of the user that redeemed the reward.
-    pub user_name: types::UserName,
+    pub user_name: types::DisplayName,
 
     /// Basic information about the Custom Reward that was redeemed at the time it was redeemed. { “id”: string, “title”: string, “prompt”: string, “cost”: int, }
     pub reward: Reward,

--- a/src/helix/streams/get_streams.rs
+++ b/src/helix/streams/get_streams.rs
@@ -96,7 +96,7 @@ pub struct Stream {
     /// ID of the user who is streaming.
     pub user_id: types::UserId,
     /// Display name corresponding to user_id.
-    pub user_name: types::UserName,
+    pub user_name: types::DisplayName,
     /// Number of viewers watching the stream at the time of the query.
     pub viewer_count: usize,
 }

--- a/src/helix/users/get_users_follows.rs
+++ b/src/helix/users/get_users_follows.rs
@@ -63,15 +63,15 @@ pub struct GetUsersFollowsRequest {
 #[cfg_attr(not(feature = "allow_unknown_fields"), serde(deny_unknown_fields))]
 #[non_exhaustive]
 pub struct UsersFollow {
-    ///Date and time when the from_id user followed the to_id user.
+    /// Date and time when the from_id user followed the to_id user.
     pub followed_at: types::Timestamp,
-    ///ID of the user following the to_id user.
+    /// ID of the user following the to_id user.
     pub from_id: types::UserId,
-    ///Display name corresponding to from_id.
+    /// Display name corresponding to from_id.
     pub from_name: types::DisplayName,
-    ///ID of the user being followed by the from_id user.
+    /// ID of the user being followed by the from_id user.
     pub to_id: types::UserId,
-    ///Display name corresponding to to_id.
+    /// Display name corresponding to to_id.
     pub to_name: types::DisplayName,
     // FIXME: This never seems to be returned.
     /// Total number of items returned.


### PR DESCRIPTION
begin work on fixing inconsistencies with display name, documented in twitchdev/issues#3