### PR TITLE
PubSub bug fixes

### DIFF
--- a/src/pubsub/channel_points.rs
+++ b/src/pubsub/channel_points.rs
@@ -75,8 +75,8 @@ pub struct Reward {
     pub background_color: String,
     /// ID of channel where the redemption was triggered
     pub channel_id: types::UserId,
-    /// Cooldown will expire after this many seconds have passed from pubsub message
-    pub cooldown_expires_at: Option<u64>,
+    /// Cooldown will expire after this timestamp
+    pub cooldown_expires_at: Option<types::Timestamp>,
     /// Cost of reward.
     pub cost: u32,
     /// Default image of reward in rewards & challenges screen on client

--- a/src/pubsub/mod.rs
+++ b/src/pubsub/mod.rs
@@ -531,6 +531,12 @@ pub enum Response {
         /// Data corresponding to [topic](Topic) message
         data: TopicData,
     },
+    /// Response from a ping
+    #[serde(rename = "PONG")]
+    Pong,
+    /// Request for the client to reconnect
+    #[serde(rename = "RECONNECT")]
+    Reconnect,
 }
 
 impl Response {


### PR DESCRIPTION
Two bug fixes:
1 - We're missing PONG and RECONNECT responses from the server, so they're coming in as errors.
2 - Reward `cooldown_expires_at` is a timestamp, not amount of seconds, so that's erroring when parsing