### PR TITLE
[WIP] Added Replace Stream Tags to helix.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@
     - Search Channels
     - Unblock User
     - Update Redemption Status (thanks [Dinnerbone](https://github.com/Dinnerbone))
+    - Replace Stream Tags (thanks [ModProg](https://github.com/ModProg))
 
 ### Changed
 

--- a/src/helix/mod.rs
+++ b/src/helix/mod.rs
@@ -531,9 +531,12 @@ pub trait RequestDelete: Request {
 
 /// Helix endpoint PUTs information
 #[cfg_attr(nightly, doc(spotlight))]
-pub trait RequestPut: Request {
+pub trait RequestPut: Request
+where <Self as Request>::Response:
+        std::convert::TryFrom<http::StatusCode, Error = std::borrow::Cow<'static, str>> {
     /// Body parameters
     type Body: HelixRequestBody;
+
     /// Create a [`http::Request`] from this [`Request`] in your client
     fn create_request(
         &self,
@@ -565,12 +568,7 @@ pub trait RequestPut: Request {
     fn parse_response(
         uri: &http::Uri,
         response: http::Response<Vec<u8>>,
-    ) -> Result<<Self as Request>::Response, HelixRequestPutError>
-    where
-        <Self as Request>::Response:
-            std::convert::TryFrom<http::StatusCode, Error = std::borrow::Cow<'static, str>>,
-        Self: Sized,
-    {
+    ) -> Result<<Self as Request>::Response, HelixRequestPutError> {
         let text = std::str::from_utf8(&response.body()).map_err(|e| {
             HelixRequestPutError::Utf8Error(response.body().clone(), e, uri.clone())
         })?;

--- a/src/helix/streams.rs
+++ b/src/helix/streams.rs
@@ -25,9 +25,11 @@ use serde::{Deserialize, Serialize};
 
 pub use get_stream_tags::{GetStreamTagsRequest, Tag};
 pub use get_streams::{GetStreamsRequest, Stream};
+pub use replace_stream_tags::{ReplaceStreamTags, ReplaceStreamTagsBody, ReplaceStreamTagsRequest};
 
 pub mod get_stream_tags;
 pub mod get_streams;
+pub mod replace_stream_tags;
 
 /// Gotten from [`Stream.type_`](get_streams::Stream#structfield.type_)
 #[derive(PartialEq, Deserialize, Serialize, Debug, Clone)]

--- a/src/helix/streams/replace_stream_tags.rs
+++ b/src/helix/streams/replace_stream_tags.rs
@@ -21,7 +21,10 @@
 //! ```
 //! # use twitch_api2::helix::streams::replace_stream_tags;
 //! let body = replace_stream_tags::ReplaceStreamTagsBody::builder()
-//!     .tag_ids(vec!["621fb5bf-5498-4d8f-b4ac-db4d40d401bf", "79977fb9-f106-4a87-a386-f1b0f99783dd"])
+//!     .tag_ids(vec![
+//!         "621fb5bf-5498-4d8f-b4ac-db4d40d401bf".to_string(),
+//!         "79977fb9-f106-4a87-a386-f1b0f99783dd".to_string(),
+//!     ])
 //!     .build();
 //! ```
 //!
@@ -43,7 +46,10 @@
 //!     .broadcaster_id("1234")
 //!     .build();
 //! let body = replace_stream_tags::ReplaceStreamTagsBody::builder()
-//!     .tag_ids(vec!["621fb5bf-5498-4d8f-b4ac-db4d40d401bf", "79977fb9-f106-4a87-a386-f1b0f99783dd"])
+//!     .tag_ids(vec![
+//!         "621fb5bf-5498-4d8f-b4ac-db4d40d401bf".to_string(),
+//!         "79977fb9-f106-4a87-a386-f1b0f99783dd".to_string(),
+//!     ])
 //!     .build();
 //! let response: replace_stream_tags::ReplaceStreamTags = client.req_put(request, body, &token).await?;
 //! # Ok(())

--- a/src/helix/streams/replace_stream_tags.rs
+++ b/src/helix/streams/replace_stream_tags.rs
@@ -1,0 +1,145 @@
+//! Applies specified tags to a specified stream, overwriting any existing tags applied to that stream. If no tags are specified, all tags previously applied to the stream are removed. Automated tags are not affected by this operation.
+//! [`replace-stream-tags`](https://dev.twitch.tv/docs/api/reference#replace-stream-tags)
+//!
+//! # Accessing the endpoint
+//!
+//! ## Request: [ReplaceStreamTagsRequest]
+//!
+//! To use this endpoint, construct a [`ReplaceStreamTagsRequest`] with the [`ReplaceStreamTagsRequest::builder()`] method.
+//!
+//! ```rust, no_run
+//! use twitch_api2::helix::streams::replace_stream_tags;
+//! let request = replace_stream_tags::ReplaceStreamTagsRequest::builder()
+//!     .broadcaster_id("1234")
+//!     .build();
+//! ```
+//!
+//! ## Body: [ReplaceStreamTagsBody]
+//!
+//! We also need to provide a body to the request containing the tags we want to set.
+//!
+//! ```
+//! # use twitch_api2::helix::streams::replace_stream_tags;
+//! let body = replace_stream_tags::ReplaceStreamTagsBody::builder()
+//!     .tag_ids(vec!["621fb5bf-5498-4d8f-b4ac-db4d40d401bf", "79977fb9-f106-4a87-a386-f1b0f99783dd"])
+//!     .build();
+//! ```
+//!
+//! ## Response: [ReplaceStreamTags]
+//!
+//!
+//! Send the request to receive the response with [`HelixClient::req_put()`](helix::HelixClient::req_put).
+//!
+//!
+//! ```rust, no_run
+//! use twitch_api2::helix::{self, streams::replace_stream_tags};
+//! # use twitch_api2::client;
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+//! # let client: helix::HelixClient<'static, client::DummyHttpClient> = helix::HelixClient::default();
+//! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
+//! # let token = twitch_oauth2::UserToken::from_existing(twitch_oauth2::dummy_http_client, token, None, None).await?;
+//! let request = replace_stream_tags::ReplaceStreamTagsRequest::builder()
+//!     .broadcaster_id("1234")
+//!     .build();
+//! let body = replace_stream_tags::ReplaceStreamTagsBody::builder()
+//!     .tag_ids(vec!["621fb5bf-5498-4d8f-b4ac-db4d40d401bf", "79977fb9-f106-4a87-a386-f1b0f99783dd"])
+//!     .build();
+//! let response: replace_stream_tags::ReplaceStreamTags = client.req_put(request, body, &token).await?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! You can also get the [`http::Request`] with [`request.create_request(body, &token, &client_id)`](helix::RequestPut::create_request)
+//! and parse the [`http::Response`] with [`request.parse_response(&request.get_uri()?)`](helix::RequestPut::parse_response())
+use super::*;
+/// Query Parameters for [Replace Stream Tags](super::replace_stream_tags)
+///
+/// [`replace-stream-tags`](https://dev.twitch.tv/docs/api/reference#replace-stream-tags)
+#[derive(PartialEq, typed_builder::TypedBuilder, Deserialize, Serialize, Clone, Debug)]
+#[non_exhaustive]
+pub struct ReplaceStreamTagsRequest {
+    /// ID of the channel
+    #[builder(setter(into))]
+    pub broadcaster_id: types::UserId,
+}
+
+/// Body Parameters for [Replace Stream Tags](super::replace_stream_tags)
+///
+/// [`replace-stream-tags`](https://dev.twitch.tv/docs/api/reference#replace-stream-tags)
+///
+/// Up to five tags can be applied to a stream. If no `tag_ids` is provided, all tags are removed from the stream.
+#[derive(PartialEq, typed_builder::TypedBuilder, Deserialize, Serialize, Clone, Debug)]
+#[non_exhaustive]
+pub struct ReplaceStreamTagsBody {
+    /// IDs of tags to be applied to the stream.
+    #[builder(default, setter(into))]
+    pub tag_ids: Vec<types::CategoryId>,
+}
+/// Return Values for [Replace Stream Tags](super::replace_stream_tags)
+///
+/// [`replace-stream-tags`](https://dev.twitch.tv/docs/api/reference#replace-stream-tags)
+#[derive(PartialEq, Deserialize, Debug, Clone)]
+#[non_exhaustive]
+pub enum ReplaceStreamTags {
+    /// 204 - Stream Tags replaced successfully
+    Success,
+    /// Internal Server Error; Failed to replace tags
+    InternalServerError,
+}
+
+impl std::convert::TryFrom<http::StatusCode> for ReplaceStreamTags {
+    type Error = std::borrow::Cow<'static, str>;
+
+    fn try_from(s: http::StatusCode) -> Result<Self, Self::Error> {
+        match s {
+            http::StatusCode::NO_CONTENT => Ok(ReplaceStreamTags::Success),
+            // FIXME: Twitch docs says 204 is success...
+            http::StatusCode::OK => Ok(ReplaceStreamTags::Success),
+            other => Err(other.canonical_reason().unwrap_or("").into()),
+        }
+    }
+}
+
+impl helix::private::SealedSerialize for ReplaceStreamTagsBody {}
+
+impl helix::Request for ReplaceStreamTagsRequest {
+    type Response = ReplaceStreamTags;
+
+    const PATH: &'static str = "streams/tags";
+    #[cfg(feature = "twitch_oauth2")]
+    const SCOPE: &'static [twitch_oauth2::Scope] = &[twitch_oauth2::Scope::ChannelManageBroadcast];
+}
+
+impl helix::RequestPut for ReplaceStreamTagsRequest {
+    type Body = ReplaceStreamTagsBody;
+}
+
+#[test]
+fn test_request() {
+    use helix::*;
+    let req = ReplaceStreamTagsRequest::builder()
+        .broadcaster_id("0")
+        .build();
+
+    let body = ReplaceStreamTagsBody::builder()
+        .tag_ids(vec![
+            "621fb5bf-5498-4d8f-b4ac-db4d40d401bf".to_string(),
+            "79977fb9-f106-4a87-a386-f1b0f99783dd".to_string(),
+        ])
+        .build();
+
+    dbg!(req.create_request(body, "token", "clientid").unwrap());
+    // From twitch docs
+    let data = br#""#.to_vec();
+
+    let http_response = http::Response::builder().status(204).body(data).unwrap();
+
+    let uri = req.get_uri().unwrap();
+    assert_eq!(
+        uri.to_string(),
+        "https://api.twitch.tv/helix/streams/tags?broadcaster_id=0"
+    );
+
+    dbg!(ReplaceStreamTagsRequest::parse_response(&uri, http_response).unwrap());
+}

--- a/src/helix/streams/replace_stream_tags.rs
+++ b/src/helix/streams/replace_stream_tags.rs
@@ -65,7 +65,7 @@ use super::*;
 #[derive(PartialEq, typed_builder::TypedBuilder, Deserialize, Serialize, Clone, Debug)]
 #[non_exhaustive]
 pub struct ReplaceStreamTagsRequest {
-    /// ID of the channel
+    /// ID of the stream for which tags are to be replaced.
     #[builder(setter(into))]
     pub broadcaster_id: types::UserId,
 }
@@ -73,6 +73,8 @@ pub struct ReplaceStreamTagsRequest {
 /// Body Parameters for [Replace Stream Tags](super::replace_stream_tags)
 ///
 /// [`replace-stream-tags`](https://dev.twitch.tv/docs/api/reference#replace-stream-tags)
+///
+/// # Notes
 ///
 /// Up to five tags can be applied to a stream. If no `tag_ids` is provided, all tags are removed from the stream.
 #[derive(PartialEq, typed_builder::TypedBuilder, Deserialize, Serialize, Clone, Debug)]


### PR DESCRIPTION
I added `PUT Replace Stream Tags`

The `RequestPut` needs to have a Body Parameter for that.

This is currently incompatible with `PUT Block User`, Should `PUT Block User` get an empty Body, or should `RequestPut` have two implementations (Bodyless and with Body)