### PR TITLE
Added missing field in UsersFollow

### DIFF
--- a/src/helix/users/get_users_follows.rs
+++ b/src/helix/users/get_users_follows.rs
@@ -122,6 +122,7 @@ fn test_request() {
             "from_name": "IIIsutha067III",
             "to_id": "23161357",
             "to_name": "LIRIK",
+            "to_login": "lirik",
             "followed_at": "2017-08-22T22:55:24Z"
         },
         {
@@ -130,6 +131,7 @@ fn test_request() {
             "from_name": "Birdman616",
             "to_id": "23161357",
             "to_name": "LIRIK",
+            "to_login": "lirik",
             "followed_at": "2017-08-22T22:55:04Z"
         }
     ],

--- a/src/helix/users/get_users_follows.rs
+++ b/src/helix/users/get_users_follows.rs
@@ -76,6 +76,8 @@ pub struct UsersFollow {
     pub to_id: types::UserId,
     ///Display name corresponding to to_id.
     pub to_name: types::DisplayName,
+    ///Login of the user being followed by the from_id user.
+    pub to_login: types::UserName,
     // FIXME: This never seems to be returned.
     /// Total number of items returned.
     ///

--- a/src/helix/webhooks/topics/users/user_follows.rs
+++ b/src/helix/webhooks/topics/users/user_follows.rs
@@ -64,6 +64,7 @@ fn test_topic() {
             "from_login": "EBI",
             "to_id": "1337",
             "to_name": "oliver0823nagy",
+            "to_login": "oliver0823nagy",
             "followed_at": "2017-08-22T22:55:24Z"
           }
         ]


### PR DESCRIPTION
Adds missing field `to_login` in struct `UsersFollow`

I've added it as a required parameter since it seemed to be so but I'm not sure that is the case