### PR TITLE
Implementing UpdateCustomReward

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@
     - Search Categories
     - Search Channels
     - Unblock User
+    - Update Custom Reward (thanks [FoxLisk](https://github.com/FoxLisk))
     - Update Redemption Status (thanks [Dinnerbone](https://github.com/Dinnerbone))
     - Replace Stream Tags (thanks [ModProg](https://github.com/ModProg))
 

--- a/src/helix/bits/get_bits_leaderboard.rs
+++ b/src/helix/bits/get_bits_leaderboard.rs
@@ -127,7 +127,7 @@ impl RequestGet for GetBitsLeaderboardRequest {
         request: Option<Self>,
         uri: &http::Uri,
         response: &str,
-        _: http::StatusCode,
+        status: http::StatusCode,
     ) -> Result<helix::Response<Self, Self::Response>, helix::HelixRequestGetError>
     where
         Self: Sized,
@@ -140,7 +140,12 @@ impl RequestGet for GetBitsLeaderboardRequest {
             total: i64,
         }
         let response: InnerResponse = helix::parse_json(response).map_err(|e| {
-            helix::HelixRequestGetError::DeserializeError(response.to_string(), e, uri.clone())
+            helix::HelixRequestGetError::DeserializeError(
+                response.to_string(),
+                e,
+                uri.clone(),
+                status,
+            )
         })?;
         Ok(helix::Response {
             data: BitsLeaderboard {

--- a/src/helix/channels/get_channel_information.rs
+++ b/src/helix/channels/get_channel_information.rs
@@ -89,14 +89,19 @@ impl RequestGet for GetChannelInformationRequest {
         request: Option<Self>,
         uri: &http::Uri,
         response: &str,
-        _: http::StatusCode,
+        status: http::StatusCode,
     ) -> Result<helix::Response<Self, Self::Response>, helix::HelixRequestGetError>
     where
         Self: Sized,
     {
         let response: helix::InnerResponse<Vec<ChannelInformation>> = helix::parse_json(response)
             .map_err(|e| {
-            helix::HelixRequestGetError::DeserializeError(response.to_string(), e, uri.clone())
+            helix::HelixRequestGetError::DeserializeError(
+                response.to_string(),
+                e,
+                uri.clone(),
+                status,
+            )
         })?;
         Ok(helix::Response {
             data: response.data.into_iter().next(),

--- a/src/helix/eventsub/create_eventsub_subscription.rs
+++ b/src/helix/eventsub/create_eventsub_subscription.rs
@@ -145,7 +145,7 @@ impl<E: EventSubscription> helix::RequestPost for CreateEventSubSubscriptionRequ
             max_total_cost: usize,
         }
         let response: InnerResponse<E> = helix::parse_json(&text).map_err(|e| {
-            helix::HelixRequestPostError::DeserializeError(text.to_string(), e, uri.clone())
+            helix::HelixRequestPostError::DeserializeError(text.to_string(), e, uri.clone(), status)
         })?;
         let data = response.data.into_iter().next().ok_or_else(|| {
             helix::HelixRequestPostError::InvalidResponse {

--- a/src/helix/eventsub/get_eventsub_subscriptions.rs
+++ b/src/helix/eventsub/get_eventsub_subscriptions.rs
@@ -60,7 +60,7 @@ impl RequestGet for GetEventSubSubscriptionsRequest {
         request: Option<Self>,
         uri: &http::Uri,
         response: &str,
-        _: http::StatusCode,
+        status: http::StatusCode,
     ) -> Result<helix::Response<Self, Self::Response>, helix::HelixRequestGetError>
     where
         Self: Sized,
@@ -79,7 +79,12 @@ impl RequestGet for GetEventSubSubscriptionsRequest {
         }
 
         let response: InnerResponse = helix::parse_json(response).map_err(|e| {
-            helix::HelixRequestGetError::DeserializeError(response.to_string(), e, uri.clone())
+            helix::HelixRequestGetError::DeserializeError(
+                response.to_string(),
+                e,
+                uri.clone(),
+                status,
+            )
         })?;
         #[allow(deprecated)]
         Ok(helix::Response {

--- a/src/helix/points.rs
+++ b/src/helix/points.rs
@@ -31,6 +31,7 @@ use serde::{Deserialize, Serialize};
 
 pub mod create_custom_rewards;
 pub mod delete_custom_reward;
+pub mod update_custom_reward;
 pub mod get_custom_reward;
 pub mod get_custom_reward_redemption;
 pub mod update_redemption_status;
@@ -41,6 +42,8 @@ pub use create_custom_rewards::{
 };
 #[doc(inline)]
 pub use delete_custom_reward::{DeleteCustomReward, DeleteCustomRewardRequest};
+#[doc(inline)]
+pub use update_custom_reward::{UpdateCustomRewardRequest, UpdateCustomRewardBody};
 #[doc(inline)]
 pub use get_custom_reward::{CustomReward, GetCustomRewardRequest};
 #[doc(inline)]

--- a/src/helix/points.rs
+++ b/src/helix/points.rs
@@ -31,9 +31,9 @@ use serde::{Deserialize, Serialize};
 
 pub mod create_custom_rewards;
 pub mod delete_custom_reward;
-pub mod update_custom_reward;
 pub mod get_custom_reward;
 pub mod get_custom_reward_redemption;
+pub mod update_custom_reward;
 pub mod update_redemption_status;
 
 #[doc(inline)]
@@ -43,11 +43,11 @@ pub use create_custom_rewards::{
 #[doc(inline)]
 pub use delete_custom_reward::{DeleteCustomReward, DeleteCustomRewardRequest};
 #[doc(inline)]
-pub use update_custom_reward::{UpdateCustomRewardRequest, UpdateCustomRewardBody};
-#[doc(inline)]
 pub use get_custom_reward::{CustomReward, GetCustomRewardRequest};
 #[doc(inline)]
 pub use get_custom_reward_redemption::{CustomRewardRedemption, GetCustomRewardRedemptionRequest};
+#[doc(inline)]
+pub use update_custom_reward::{UpdateCustomRewardBody, UpdateCustomRewardRequest};
 #[doc(inline)]
 pub use update_redemption_status::{
     UpdateRedemptionStatusBody, UpdateRedemptionStatusInformation, UpdateRedemptionStatusRequest,

--- a/src/helix/points/create_custom_rewards.rs
+++ b/src/helix/points/create_custom_rewards.rs
@@ -148,6 +148,7 @@ impl RequestPost for CreateCustomRewardRequest {
                     response_str.to_string(),
                     e,
                     uri.clone(),
+                    status,
                 )
             })?;
         let data = response.data.into_iter().next().ok_or_else(|| {

--- a/src/helix/points/update_custom_reward.rs
+++ b/src/helix/points/update_custom_reward.rs
@@ -112,6 +112,9 @@ pub struct UpdateCustomRewardBody {
     /// The cooldown in seconds if enabled
     #[builder(default, setter(into))]
     pub global_cooldown_seconds: Option<usize>,
+    /// Is the reward currently paused, if true viewers can’t redeem
+    #[builder(default, setter(into))]
+    pub is_paused: Option<bool>,
     /// Should redemptions be set to FULFILLED status immediately when redeemed and skip the request queue instead of the normal UNFULFILLED status. Defaults false
     #[builder(default, setter(into))]
     pub should_redemptions_skip_request_queue: Option<bool>,

--- a/src/helix/points/update_custom_reward.rs
+++ b/src/helix/points/update_custom_reward.rs
@@ -1,0 +1,242 @@
+//! [`update-custom-rewards`](https://dev.twitch.tv/docs/api/reference#update-custom-reward)
+//!
+//! # Accessing the endpoint
+//!
+//! ## Request: [CreateCustomRewardRequest]
+//!
+//! To use this endpoint, construct an [`UpdateCustomRewardRequest`] with the [`UpdateCustomRewardRequest::builder()`] method.
+//!
+//! ```rust, no_run
+//! use twitch_api2::helix::points::update_custom_rewards;
+//! let request = update_custom_rewards::UpdateCustomRewardRequest::builder()
+//!     .broadcaster_id("274637212")
+//!     .build();
+//! ```
+//!
+//! ## Body: [UpdateCustomRewardBody]
+//!
+//! We also need to provide a body to the request containing what we want to change.
+//!
+//! ```
+//! # use twitch_api2::helix::points::update_custom_rewards;
+//! let body = update_custom_rewards::UpdateCustomRewardBody::builder()
+//!     .cost(501)
+//!     .title("hydrate but differently now!")
+//!     .build();
+//! ```
+//!
+//! ## Response: [UpdateCustomRewardResponse]
+//!
+//!
+//! Send the request to receive the response with [`HelixClient::req_patch()`](helix::HelixClient::req_patch).
+//!
+//!
+//! ```rust, no_run
+//! use twitch_api2::helix::{self, points::update_custom_reward};
+//! # use twitch_api2::client;
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+//! # let client: helix::HelixClient<'static, client::DummyHttpClient> = helix::HelixClient::default();
+//! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
+//! # let token = twitch_oauth2::UserToken::from_existing(twitch_oauth2::dummy_http_client, token, None, None).await?;
+//! let request = update_custom_reward::UpdateCustomRewardRequest::builder()
+//!     .broadcaster_id("274637212")
+//!     .build();
+//! let body = update_custom_reward::UpdateCustomRewardBody::builder()
+//!     .cost(501)
+//!     .title("hydrate but differently now!")
+//!     .build();
+//! let response: update_custom_reward::UpdateCustomRewardResponse = client.req_patch(request, body, &token).await?.data;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! You can also get the [`http::Request`] with [`request.create_request(&token, &client_id)`](helix::RequestPost::create_request)
+//! and parse the [`http::Response`] with [`UpdateCustomRewardRequest::parse_response(None, &request.get_uri(), response)`](UpdateCustomRewardRequest::parse_response)
+
+use super::*;
+use helix::RequestPatch;
+/// Query Parameters for [Update Custom Rewards](super::update_custom_rewards)
+///
+/// [`update-custom-rewards`](https://dev.twitch.tv/docs/api/reference#update-custom-rewards)
+#[derive(PartialEq, typed_builder::TypedBuilder, Deserialize, Serialize, Clone, Debug, Default)]
+#[non_exhaustive]
+pub struct UpdateCustomRewardRequest {
+    /// Provided broadcaster_id must match the user_id in the auth token
+    #[builder(setter(into))]
+    pub broadcaster_id: types::UserId,
+    /// ID of the Custom Reward to update, must match a Custom Reward on broadcaster_id’s channel.
+    #[builder(setter(into))]
+    pub id: types::RewardId,
+}
+
+/// Body Parameters for [Update Custom Rewards](super::update_custom_rewards)
+///
+/// [`update-custom-rewards`](https://dev.twitch.tv/docs/api/reference#update-custom-rewards)
+#[derive(PartialEq, typed_builder::TypedBuilder, Deserialize, Serialize, Clone, Debug)]
+#[non_exhaustive]
+pub struct UpdateCustomRewardBody {
+    /// The title of the reward
+    #[builder(default, setter(into))]
+    pub title: Option<String>,
+    /// The prompt for the viewer when they are redeeming the reward
+    #[builder(default, setter(into))]
+    pub prompt: Option<String>,
+    /// The cost of the reward
+    #[builder(default, setter(into))]
+    pub cost: Option<usize>,
+    /// Is the reward currently enabled, if false the reward won’t show up to viewers. Defaults true
+    #[builder(default, setter(into))]
+    pub is_enabled: Option<bool>,
+    /// Custom background color for the reward. Format: Hex with # prefix. Example: #00E5CB.
+    #[builder(default, setter(into))]
+    pub background_color: Option<String>,
+    /// Does the user need to enter information when redeeming the reward. Defaults false
+    #[builder(default, setter(into))]
+    pub is_user_input_required: Option<bool>,
+    /// Whether a maximum per stream is enabled. Defaults to false.
+    #[builder(default, setter(into))]
+    pub is_max_per_stream_enabled: Option<bool>,
+    /// The maximum number per stream if enabled
+    #[builder(default, setter(into))]
+    pub max_per_stream: Option<usize>,
+    /// Whether a maximum per user per stream is enabled. Defaults to false.
+    #[builder(default, setter(into))]
+    pub is_max_per_user_per_stream_enabled: Option<bool>,
+    /// The maximum number per user per stream if enabled
+    #[builder(default, setter(into))]
+    pub max_per_user_per_stream: Option<usize>,
+    /// Whether a cooldown is enabled. Defaults to false.
+    #[builder(default, setter(into))]
+    pub is_global_cooldown_enabled: Option<bool>,
+    /// The cooldown in seconds if enabled
+    #[builder(default, setter(into))]
+    pub global_cooldown_seconds: Option<usize>,
+    /// Should redemptions be set to FULFILLED status immediately when redeemed and skip the request queue instead of the normal UNFULFILLED status. Defaults false
+    #[builder(default, setter(into))]
+    pub should_redemptions_skip_request_queue: Option<bool>,
+}
+
+impl helix::private::SealedSerialize for UpdateCustomRewardBody {}
+
+// FIXME: Should return VideoIds
+/// Return Values for [Update CustomReward](super::update_custom_reward)
+///
+/// [`update-custom-reward`](https://dev.twitch.tv/docs/api/reference#update-custom-reward)
+#[derive(PartialEq, Deserialize, Debug, Clone)]
+#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
+#[non_exhaustive]
+pub enum UpdateCustomReward {
+    /// Reward updated
+    Success,
+    /// Bad Request: Query/Body Parameter missing or invalid
+    BadRequest,
+    /// Unauthenticated: Missing/invalid Token
+    AuthFailed,
+    /// Forbidden: The Custom Reward was created by a different client_id or Channel Points are not available for the broadcaster
+    Forbidden,
+    /// Not Found: The Custom Reward doesn’t exist with the id and broadcaster_id specified
+    NotFound,
+}
+
+
+impl std::convert::TryFrom<http::StatusCode> for UpdateCustomReward {
+    type Error = std::borrow::Cow<'static, str>;
+
+    fn try_from(s: http::StatusCode) -> Result<Self, Self::Error> {
+        match s {
+            http::StatusCode::OK => Ok(UpdateCustomReward::Success),
+            http::StatusCode::BAD_REQUEST => Ok(UpdateCustomReward::BadRequest),
+            http::StatusCode::UNAUTHORIZED => Ok(UpdateCustomReward::AuthFailed),
+            http::StatusCode::FORBIDDEN => Ok(UpdateCustomReward::Forbidden),
+            http::StatusCode::NOT_FOUND => Ok(UpdateCustomReward::NotFound),
+            // http::StatusCode::INTERNAL_SERVER_ERROR => Ok(DeleteCustomReward::InternalServerError),
+            other => Err(other.canonical_reason().unwrap_or("").into()),
+        }
+    }
+}
+
+impl Request for UpdateCustomRewardRequest {
+    type Response = UpdateCustomReward;
+
+    const PATH: &'static str = "channel_points/custom_rewards";
+    #[cfg(feature = "twitch_oauth2")]
+    const SCOPE: &'static [twitch_oauth2::Scope] =
+        &[twitch_oauth2::Scope::ChannelManageRedemptions];
+}
+
+impl RequestPatch for UpdateCustomRewardRequest {
+    type Body = UpdateCustomRewardBody;
+
+}
+
+#[test]
+fn test_request() {
+    use helix::*;
+    let req = UpdateCustomRewardRequest::builder()
+        .broadcaster_id("274637212")
+        .id("b045196d-9ce7-4a27-a9b9-279ed341ab28")
+        .build();
+
+    let body = UpdateCustomRewardBody::builder()
+        .cost(50001)
+        .title("game analysis 1v1")
+        .build();
+
+    dbg!(req.create_request(body, "token", "clientid").unwrap());
+
+    // From twitch docs
+    let data = br##"
+{
+    "data": [
+        {
+            "broadcaster_name": "torpedo09",
+            "broadcaster_login": "torpedo09",
+            "broadcaster_id": "274637212",
+            "id": "afaa7e34-6b17-49f0-a19a-d1e76eaaf673",
+            "image": null,
+            "background_color": "#00E5CB",
+            "is_enabled": true,
+            "cost": 50000,
+            "title": "game analysis 1v1",
+            "prompt": "",
+            "is_user_input_required": false,
+            "max_per_stream_setting": {
+                "is_enabled": false,
+                "max_per_stream": 0
+            },
+            "max_per_user_per_stream_setting": {
+                "is_enabled": false,
+                "max_per_user_per_stream": 0
+            },
+            "global_cooldown_setting": {
+                "is_enabled": false,
+                "global_cooldown_seconds": 0
+            },
+            "is_paused": false,
+            "is_in_stock": true,
+            "default_image": {
+                "url_1x": "https://static-cdn.jtvnw.net/custom-reward-images/default-1.png",
+                "url_2x": "https://static-cdn.jtvnw.net/custom-reward-images/default-2.png",
+                "url_4x": "https://static-cdn.jtvnw.net/custom-reward-images/default-4.png"
+            },
+            "should_redemptions_skip_request_queue": false,
+            "redemptions_redeemed_current_stream": null,
+            "cooldown_expires_at": null
+        }
+    ]
+}
+    "##
+    .to_vec();
+
+    let http_response = http::Response::builder().status(200).body(data).unwrap();
+    // This is marked as 204 in twitch docs, but in reality it's 200
+
+    let uri = req.get_uri().unwrap();
+    assert_eq!(
+        uri.to_string(),
+        "https://api.twitch.tv/helix/channel_points/custom_rewards?broadcaster_id=274637212"
+    );
+
+    dbg!(UpdateCustomRewardRequest::parse_response(&uri, http_response).unwrap());
+}

--- a/src/helix/search/search_categories.rs
+++ b/src/helix/search/search_categories.rs
@@ -78,14 +78,19 @@ impl RequestGet for SearchCategoriesRequest {
         request: Option<Self>,
         uri: &http::Uri,
         response: &str,
-        _: http::StatusCode,
+        status: http::StatusCode,
     ) -> Result<helix::Response<Self, Self::Response>, helix::HelixRequestGetError>
     where
         Self: Sized,
     {
         let response: helix::InnerResponse<Option<Self::Response>> = helix::parse_json(&response)
             .map_err(|e| {
-            helix::HelixRequestGetError::DeserializeError(response.to_string(), e, uri.clone())
+            helix::HelixRequestGetError::DeserializeError(
+                response.to_string(),
+                e,
+                uri.clone(),
+                status,
+            )
         })?;
         Ok(helix::Response {
             data: response.data.unwrap_or_default(),

--- a/src/helix/subscriptions/check_user_subscription.rs
+++ b/src/helix/subscriptions/check_user_subscription.rs
@@ -96,7 +96,12 @@ impl RequestGet for CheckUserSubscriptionRequest {
     {
         let inner_response: helix::InnerResponse<Vec<_>> =
             helix::parse_json(&text).map_err(|e| {
-                helix::HelixRequestGetError::DeserializeError(text.to_string(), e, uri.clone())
+                helix::HelixRequestGetError::DeserializeError(
+                    text.to_string(),
+                    e,
+                    uri.clone(),
+                    status,
+                )
             })?;
         Ok(helix::Response {
             data: inner_response.data.into_iter().next().ok_or(

--- a/src/helix/users/get_users_follows.rs
+++ b/src/helix/users/get_users_follows.rs
@@ -111,7 +111,7 @@ impl RequestGet for GetUsersFollowsRequest {
         request: Option<Self>,
         uri: &http::Uri,
         response: &str,
-        _status: http::StatusCode,
+        status: http::StatusCode,
     ) -> Result<helix::Response<Self, Self::Response>, helix::HelixRequestGetError>
     where
         Self: Sized,
@@ -125,7 +125,12 @@ impl RequestGet for GetUsersFollowsRequest {
         }
 
         let response: InnerResponse = helix::parse_json(response).map_err(|e| {
-            helix::HelixRequestGetError::DeserializeError(response.to_string(), e, uri.clone())
+            helix::HelixRequestGetError::DeserializeError(
+                response.to_string(),
+                e,
+                uri.clone(),
+                status,
+            )
         })?;
         Ok(helix::Response {
             data: UsersFollows {

--- a/src/helix/webhooks/get_webhook_subscriptions.rs
+++ b/src/helix/webhooks/get_webhook_subscriptions.rs
@@ -62,7 +62,7 @@ impl RequestGet for GetWebhookSubscriptionsRequest {
         request: Option<Self>,
         uri: &http::Uri,
         response: &str,
-        _status: http::StatusCode,
+        status: http::StatusCode,
     ) -> Result<helix::Response<Self, Self::Response>, helix::HelixRequestGetError>
     where
         Self: Sized,
@@ -77,7 +77,12 @@ impl RequestGet for GetWebhookSubscriptionsRequest {
         }
 
         let response: InnerResponse = helix::parse_json(response).map_err(|e| {
-            helix::HelixRequestGetError::DeserializeError(response.to_string(), e, uri.clone())
+            helix::HelixRequestGetError::DeserializeError(
+                response.to_string(),
+                e,
+                uri.clone(),
+                status,
+            )
         })?;
         Ok(helix::Response {
             data: WebhookSubscriptions {


### PR DESCRIPTION
I'm not sure this is the right way to do this. I'm not a particularly experienced rustacean, so please let me know if this has issues I can't see.

It does, however, _work_ - I have a (private) project that is now successfully using it, and I can update rewards successfully.

The most likely issue is that the endpoint here returns the updated CustomReward structure, and we're just losing it here. That shouldn't be a big deal - if you're patching it you should know what it will look like after a successful response - but it is betraying the twitch API slightly. However I couldn't figure out how to fit that into the existing structures around the client :(