### PR TITLE
Fix typo in helix::search::Channel

### DIFF
--- a/src/helix/search/search_channels.rs
+++ b/src/helix/search/search_channels.rs
@@ -89,7 +89,7 @@ pub struct Channel {
     pub started_at: types::Timestamp,
     // FIXME: Twitch doc say tag_ids
     /// Shows tag IDs that apply to the stream (live only).See <https://www.twitch.tv/directory/all/tags> for tag types
-    pub tags_ids: Vec<types::TagId>,
+    pub tag_ids: Vec<types::TagId>,
 }
 
 impl Request for SearchChannelsRequest {
@@ -123,7 +123,7 @@ fn test_request() {
             "game_name": "DOOM Eternal",
             "id": "19070311",
             "is_live": true,
-            "tags_ids": [
+            "tag_ids": [
               "6ea6bca4-4712-4ab9-a906-e3336a9d8039"
             ],
             "thumbnail_url": "https://static-cdn.jtvnw.net/jtv_user_pictures/a_seagull-profile_image-4d2d235688c7dc66-300x300.png",


### PR DESCRIPTION
The field "tags_ids" is supposed to be "tag_ids" :)