### PR TITLE
better delete put

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,17 @@
 * Added Channel Terms to pubsub `chat_moderator_actions`
 * Added `extendsub` to pubsub `channel-subscribe-events-v1`
 * Added `delay` to `Get Channel Information`
+* Added `serde::Serialize` to all helix endpoint return values
 
 ### Changed
 
 * Deprecated specific term actions in `ChatModeratorActionsReply`, replacing them with `ChannelTermsAction`
 * Deprecated `Vip` action in `ChatModeratorActionsReply`, replacing it with `VipAdded`
 * Removed some derived impls and fixed builders that assumed a default wrongly.
+
+### Removed
+
+* Removed enum variants for a lot of error states in helix endpoint responses. Most of these are returned by `HelixRequest_Error::Error`
 ## [v0.5.0] - 2021-05-08
 
 [Commits](https://github.com/Emilgardis/twitch_api2/compare/v0.4.1...v0.5.0)

--- a/src/helix/channels/modify_channel_information.rs
+++ b/src/helix/channels/modify_channel_information.rs
@@ -93,10 +93,6 @@ impl helix::private::SealedSerialize for ModifyChannelInformationBody {}
 pub enum ModifyChannelInformation {
     /// 204 - Channel/Stream updated successfully
     Success,
-    /// 400 - Missing Query Parameter
-    MissingQuery,
-    /// Internal Server Error; Failed to update channel
-    InternalServerError,
 }
 
 impl Request for ModifyChannelInformationRequest {
@@ -121,13 +117,10 @@ impl RequestPatch for ModifyChannelInformationRequest {
     {
         Ok(helix::Response {
             data: match status {
-                http::StatusCode::NO_CONTENT => ModifyChannelInformation::Success,
-                // FIXME: Twitch docs says 204 is success...
-                http::StatusCode::OK => ModifyChannelInformation::Success,
-                http::StatusCode::BAD_REQUEST => ModifyChannelInformation::MissingQuery,
-                http::StatusCode::INTERNAL_SERVER_ERROR => {
-                    ModifyChannelInformation::InternalServerError
+                http::StatusCode::NO_CONTENT | http::StatusCode::OK => {
+                    ModifyChannelInformation::Success
                 }
+                // FIXME: Twitch docs says 204 is success...
                 _ => {
                     return Err(helix::HelixRequestPatchError::InvalidResponse {
                         reason: "unexpected status code",

--- a/src/helix/client_ext.rs
+++ b/src/helix/client_ext.rs
@@ -279,14 +279,16 @@ impl<'a, C: crate::HttpClient<'a>> HelixClient<'a, C> {
     where
         T: TwitchToken + ?Sized,
     {
-        self.req_put(
-            helix::users::BlockUserRequest::builder()
-                .target_user_id(target_user_id)
-                .build(),
-            helix::EmptyBody,
-            token,
-        )
-        .await
+        Ok(self
+            .req_put(
+                helix::users::BlockUserRequest::builder()
+                    .target_user_id(target_user_id)
+                    .build(),
+                helix::EmptyBody,
+                token,
+            )
+            .await?
+            .data)
     }
 
     /// Unblock a user
@@ -298,13 +300,15 @@ impl<'a, C: crate::HttpClient<'a>> HelixClient<'a, C> {
     where
         T: TwitchToken + ?Sized,
     {
-        self.req_delete(
-            helix::users::UnblockUserRequest::builder()
-                .target_user_id(target_user_id)
-                .build(),
-            token,
-        )
-        .await
+        Ok(self
+            .req_delete(
+                helix::users::UnblockUserRequest::builder()
+                    .target_user_id(target_user_id)
+                    .build(),
+                token,
+            )
+            .await?
+            .data)
     }
 }
 

--- a/src/helix/eventsub/delete_eventsub_subscription.rs
+++ b/src/helix/eventsub/delete_eventsub_subscription.rs
@@ -77,6 +77,6 @@ fn test_request() {
 
     dbg!(
         "{:#?}",
-        DeleteEventSubSubscriptionRequest::parse_response(&uri, http_response).unwrap()
+        DeleteEventSubSubscriptionRequest::parse_response(Some(req), &uri, http_response).unwrap()
     );
 }

--- a/src/helix/eventsub/delete_eventsub_subscription.rs
+++ b/src/helix/eventsub/delete_eventsub_subscription.rs
@@ -30,30 +30,34 @@ impl Request for DeleteEventSubSubscriptionRequest {
 pub enum DeleteEventSubSubscription {
     /// 204 - Subscription deleted
     Success,
-    /// 404 - Subscription not found
-    NotFound,
-    /// 400 - Missing Query
-    ///
-    /// # Notes
-    ///
-    /// This will never be encountered if using [DeleteEventSubSubscriptionRequest]
-    MissingQuery,
 }
 
-impl std::convert::TryFrom<http::StatusCode> for DeleteEventSubSubscription {
-    type Error = std::borrow::Cow<'static, str>;
-
-    fn try_from(s: http::StatusCode) -> Result<Self, Self::Error> {
-        match s {
-            http::StatusCode::NO_CONTENT => Ok(DeleteEventSubSubscription::Success),
-            http::StatusCode::BAD_REQUEST => Ok(DeleteEventSubSubscription::MissingQuery),
-            http::StatusCode::NOT_FOUND => Ok(DeleteEventSubSubscription::NotFound),
-            other => Err(other.canonical_reason().unwrap_or("").into()),
+impl RequestDelete for DeleteEventSubSubscriptionRequest {
+    fn parse_inner_response(
+        request: Option<Self>,
+        uri: &http::Uri,
+        response: &str,
+        status: http::StatusCode,
+    ) -> Result<helix::Response<Self, Self::Response>, helix::HelixRequestDeleteError>
+    where
+        Self: Sized,
+    {
+        match status {
+            // FIXME: I've seen OK as the status code
+            http::StatusCode::NO_CONTENT | http::StatusCode::OK => Ok(helix::Response {
+                data: DeleteEventSubSubscription::Success,
+                pagination: None,
+                request,
+            }),
+            _ => Err(helix::HelixRequestDeleteError::InvalidResponse {
+                reason: "unexpected status",
+                response: response.to_string(),
+                status,
+                uri: uri.clone(),
+            }),
         }
     }
 }
-
-impl RequestDelete for DeleteEventSubSubscriptionRequest {}
 
 #[test]
 fn test_request() {

--- a/src/helix/mod.rs
+++ b/src/helix/mod.rs
@@ -813,30 +813,35 @@ struct Pagination {
 pub type Cursor = String;
 
 /// Errors for [`HelixClient::req_get`] and similar functions.
-#[derive(thiserror::Error, Debug, displaydoc::Display)]
+#[derive(thiserror::Error, Debug)]
+// #[derive(displaydoc::Display)] https://github.com/yaahc/displaydoc/issues/15
 pub enum ClientRequestError<RE: std::error::Error + Send + Sync + 'static> {
-    /// request failed from reqwests side
+    /// Request failed from reqwests side
+    #[error("request failed from reqwests side")]
     RequestError(RE),
-    /// no pagination found
+    /// No pagination found
+    #[error("no pagination found")]
     NoPage,
-    /// could not create request
+    /// Could not create request
+    #[error("could not create request")]
     CreateRequestError(#[from] CreateRequestError),
-    /// could not parse GET response
-    // #[error(transparent)] // FIXME: https://github.com/yaahc/displaydoc/issues/15
+    /// Got error from GET response
+    #[error(transparent)]
     HelixRequestGetError(#[from] HelixRequestGetError),
-    /// could not parse PUT response
-    // #[error(transparent)] // FIXME: https://github.com/yaahc/displaydoc/issues/15
+    /// Got error from PUT response
+    #[error(transparent)]
     HelixRequestPutError(#[from] HelixRequestPutError),
-    /// could not parse POST response
-    // #[error(transparent)] // FIXME: https://github.com/yaahc/displaydoc/issues/15
+    /// Got error from POST response
+    #[error(transparent)]
     HelixRequestPostError(#[from] HelixRequestPostError),
-    /// could not parse PATCH response
-    // #[error(transparent)] // FIXME: https://github.com/yaahc/displaydoc/issues/15
+    /// Got error from PATCH response
+    #[error(transparent)]
     HelixRequestPatchError(#[from] HelixRequestPatchError),
-    /// could not parse DELETE response
-    // #[error(transparent)] // FIXME: https://github.com/yaahc/displaydoc/issues/15
+    /// Got error from DELETE response
+    #[error(transparent)]
     HelixRequestDeleteError(#[from] HelixRequestDeleteError),
-    /// {0}
+    /// Custom error
+    #[error("{0}")]
     Custom(std::borrow::Cow<'static, str>),
 }
 /// Could not create request
@@ -913,7 +918,7 @@ pub enum HelixRequestPutError {
         message: String,
         /// URI to the endpoint
         uri: http::Uri,
-        /// Body sent with PUT
+        /// Body sent to PUT response
         body: Vec<u8>,
     },
     /// could not parse response as utf8 when calling `PUT {2}`
@@ -951,7 +956,7 @@ pub enum HelixRequestPostError {
         message: String,
         /// URI to the endpoint
         uri: http::Uri,
-        /// Body sent with POST
+        /// Body sent to POST response
         body: Vec<u8>,
     },
     /// could not parse response as utf8 when calling `POST {2}`
@@ -989,7 +994,7 @@ pub enum HelixRequestPatchError {
         message: String,
         /// URI to the endpoint
         uri: http::Uri,
-        /// Body sent with POST
+        /// Body sent to POST response
         body: Vec<u8>,
     },
     /// could not parse response as utf8 when calling `POST {2}`
@@ -1027,7 +1032,7 @@ pub enum HelixRequestDeleteError {
         message: String,
         /// URI to the endpoint
         uri: http::Uri,
-        /// Body sent with DELETE
+        /// Body sent to DELETE response
         body: Vec<u8>,
     },
     /// could not parse response as utf8 when calling `DELETE {2}`

--- a/src/helix/mod.rs
+++ b/src/helix/mod.rs
@@ -979,7 +979,7 @@ pub enum HelixRequestPostError {
 /// Could not parse PATCH response
 #[derive(thiserror::Error, Debug, displaydoc::Display)]
 pub enum HelixRequestPatchError {
-    /// helix returned error {status:?}: {message:?} when calling `PATCH {uri}` with a body
+    /// helix returned error {status:?} - {error}: {message:?} when calling `PATCH {uri}` with a body
     Error {
         /// Error message related to status code
         error: String,
@@ -1017,7 +1017,7 @@ pub enum HelixRequestPatchError {
 /// Could not parse DELETE response
 #[derive(thiserror::Error, Debug, displaydoc::Display)]
 pub enum HelixRequestDeleteError {
-    /// helix returned error {status:?}- {error}: {message:?} when calling `DELETE {uri}`
+    /// helix returned error {status:?} - {error}: {message:?} when calling `DELETE {uri}`
     Error {
         /// Error message related to status code
         error: String,

--- a/src/helix/points/delete_custom_reward.rs
+++ b/src/helix/points/delete_custom_reward.rs
@@ -31,13 +31,13 @@
 //!     .broadcaster_id("274637212")
 //!     .id("1234")
 //!     .build();
-//! let response: delete_custom_reward::DeleteCustomReward = client.req_delete(request, &token).await?;
+//! let response: delete_custom_reward::DeleteCustomReward = client.req_delete(request, &token).await?.data;
 //! # Ok(())
 //! # }
 //! ```
 //!
 //! You can also get the [`http::Request`] with [`request.create_request(&token, &client_id)`](helix::RequestDelete::create_request)
-//! and parse the [`http::Response`] with [`DeleteCustomRewardRequest::parse_response(&request.get_uri(), response)`](DeleteCustomRewardRequest::parse_response)
+//! and parse the [`http::Response`] with [`DeleteCustomRewardRequest::parse_response(None, &request.get_uri(), response)`](DeleteCustomRewardRequest::parse_response)
 
 use super::*;
 use helix::RequestDelete;
@@ -121,5 +121,5 @@ fn test_request() {
         "https://api.twitch.tv/helix/channel_points/custom_rewards?broadcaster_id=274637212&id=b045196d-9ce7-4a27-a9b9-279ed341ab28"
     );
 
-    dbg!(DeleteCustomRewardRequest::parse_response(&uri, http_response).unwrap());
+    dbg!(DeleteCustomRewardRequest::parse_response(Some(req), &uri, http_response).unwrap());
 }

--- a/src/helix/points/update_redemption_status.rs
+++ b/src/helix/points/update_redemption_status.rs
@@ -103,14 +103,6 @@ pub struct UpdateRedemptionStatusBody {
 pub enum UpdateRedemptionStatusInformation {
     /// 200 - OK
     Success(CustomRewardRedemption),
-    /// 400 - Bad Request: Query Parameter missing or invalid
-    MissingQuery,
-    /// 403 - Forbidden: The Custom Reward was created by a different client_id or Channel Points are not available for the broadcaster
-    Forbidden,
-    /// 404 - Not Found: No Custom Reward Redemptions with the specified IDs were found with a status of UNFULFILLED.
-    NotFound,
-    /// Internal Server Error; Failed to update channel
-    InternalServerError,
 }
 
 impl Request for UpdateRedemptionStatusRequest {
@@ -153,12 +145,6 @@ impl RequestPatch for UpdateRedemptionStatusRequest {
                         uri: uri.clone(),
                     },
                 )?)
-            }
-            http::StatusCode::BAD_REQUEST => UpdateRedemptionStatusInformation::MissingQuery,
-            http::StatusCode::NOT_FOUND => UpdateRedemptionStatusInformation::NotFound,
-            http::StatusCode::FORBIDDEN => UpdateRedemptionStatusInformation::Forbidden,
-            http::StatusCode::INTERNAL_SERVER_ERROR => {
-                UpdateRedemptionStatusInformation::InternalServerError
             }
             _ => {
                 return Err(helix::HelixRequestPatchError::InvalidResponse {

--- a/src/helix/streams/replace_stream_tags.rs
+++ b/src/helix/streams/replace_stream_tags.rs
@@ -94,8 +94,6 @@ pub struct ReplaceStreamTagsBody {
 pub enum ReplaceStreamTags {
     /// 204 - Stream Tags replaced successfully
     Success,
-    /// Internal Server Error; Failed to replace tags
-    InternalServerError,
 }
 
 impl helix::private::SealedSerialize for ReplaceStreamTagsBody {}

--- a/src/helix/streams/replace_stream_tags.rs
+++ b/src/helix/streams/replace_stream_tags.rs
@@ -51,13 +51,13 @@
 //!         "79977fb9-f106-4a87-a386-f1b0f99783dd".to_string(),
 //!     ])
 //!     .build();
-//! let response: replace_stream_tags::ReplaceStreamTags = client.req_put(request, body, &token).await?;
+//! let response: replace_stream_tags::ReplaceStreamTags = client.req_put(request, body, &token).await?.data;
 //! # Ok(())
 //! # }
 //! ```
 //!
 //! You can also get the [`http::Request`] with [`request.create_request(&token, &client_id)`](helix::RequestPut::create_request)
-//! and parse the [`http::Response`] with [`ReplaceStreamTagsRequest::parse_response(&request.get_uri(), response)`](ReplaceStreamTagsRequest::parse_response)
+//! and parse the [`http::Response`] with [`ReplaceStreamTagsRequest::parse_response(None, &request.get_uri(), response)`](ReplaceStreamTagsRequest::parse_response)
 use super::*;
 use helix::RequestPut;
 
@@ -161,5 +161,5 @@ fn test_request() {
         "https://api.twitch.tv/helix/streams/tags?broadcaster_id=0"
     );
 
-    dbg!(ReplaceStreamTagsRequest::parse_response(&uri, http_response).unwrap());
+    dbg!(ReplaceStreamTagsRequest::parse_response(Some(req), &uri, http_response).unwrap());
 }

--- a/src/helix/users/block_user.rs
+++ b/src/helix/users/block_user.rs
@@ -35,13 +35,13 @@
 //! let request = block_user::BlockUserRequest::builder()
 //!     .target_user_id("1234")
 //!     .build();
-//! let response: block_user::BlockUser = client.req_put(request, helix::EmptyBody, &token).await?;
+//! let response: block_user::BlockUser = client.req_put(request, helix::EmptyBody, &token).await?.data;
 //! # Ok(())
 //! # }
 //! ```
 //!
 //! You can also get the [`http::Request`] with [`request.create_request(&token, &client_id)`](helix::RequestPut::create_request)
-//! and parse the [`http::Response`] with [`BlockUserRequest::parse_response(&request.get_uri(), response)`](BlockUserRequest::parse_response)
+//! and parse the [`http::Response`] with [`BlockUserRequest::parse_response(None, &request.get_uri(), response)`](BlockUserRequest::parse_response)
 
 use super::*;
 use helix::RequestPut;
@@ -156,5 +156,5 @@ fn test_request() {
         "https://api.twitch.tv/helix/users/blocks?target_user_id=41245071"
     );
 
-    dbg!(BlockUserRequest::parse_response(&uri, http_response).unwrap());
+    dbg!(BlockUserRequest::parse_response(Some(req), &uri, http_response).unwrap());
 }

--- a/src/helix/users/create_user_follows.rs
+++ b/src/helix/users/create_user_follows.rs
@@ -53,8 +53,6 @@
 //! You can also get the [`http::Request`] with [`request.create_request(&token, &client_id)`](helix::RequestPost::create_request)
 //! and parse the [`http::Response`] with [`CreateUserFollowsRequest::parse_response(None, &request.get_uri(), response)`](CreateUserFollowsRequest::parse_response)
 
-use std::convert::TryInto;
-
 use super::*;
 use helix::RequestPost;
 /// Query Parameters for [Create User Follows](super::create_user_follows)

--- a/src/helix/users/create_user_follows.rs
+++ b/src/helix/users/create_user_follows.rs
@@ -92,23 +92,6 @@ pub enum CreateUserFollows {
     // FIXME: Twitch docs....
     /// 204 or 200 - Successfully created follows
     Success,
-    /// 400 - Missing Query Parameter
-    MissingQuery,
-    /// 422 - Entity cannot be processed
-    ProcessingError,
-}
-
-impl std::convert::TryFrom<http::StatusCode> for CreateUserFollows {
-    type Error = std::borrow::Cow<'static, str>;
-
-    fn try_from(s: http::StatusCode) -> Result<Self, Self::Error> {
-        match s {
-            http::StatusCode::NO_CONTENT | http::StatusCode::OK => Ok(CreateUserFollows::Success),
-            http::StatusCode::BAD_REQUEST => Ok(CreateUserFollows::MissingQuery),
-            http::StatusCode::UNPROCESSABLE_ENTITY => Ok(CreateUserFollows::Success),
-            other => Err(other.canonical_reason().unwrap_or("").into()),
-        }
-    }
 }
 
 impl Request for CreateUserFollowsRequest {
@@ -124,62 +107,31 @@ impl Request for CreateUserFollowsRequest {
 impl RequestPost for CreateUserFollowsRequest {
     type Body = CreateUserFollowsBody;
 
-    fn parse_response(
+    fn parse_inner_response(
         request: Option<Self>,
         uri: &http::Uri,
-        response: http::Response<Vec<u8>>,
-    ) -> Result<
-        helix::Response<Self, <Self as helix::Request>::Response>,
-        helix::HelixRequestPostError,
-    >
-    where
-        Self: Sized,
-    {
-        let text = std::str::from_utf8(&response.body()).map_err(|e| {
-            helix::HelixRequestPostError::Utf8Error(response.body().clone(), e, uri.clone())
-        })?;
-        if let Ok(helix::HelixRequestError {
-            error,
-            status,
-            message,
-        }) = helix::parse_json::<helix::HelixRequestError>(&text, false)
-        {
-            return Err(helix::HelixRequestPostError::Error {
-                error,
-                status: status.try_into().unwrap_or(http::StatusCode::BAD_REQUEST),
-                message,
-                uri: uri.clone(),
-                body: response.body().clone(),
-            });
-        }
-
-        let response = response.status().try_into().map_err(|_| {
-            // This path should never be taken, but just to be sure we do this
-            helix::HelixRequestPostError::Error {
-                status: response.status(),
-                uri: uri.clone(),
-                body: response.body().clone(),
-                message: String::new(), // FIXME: None, but this branch should really never be hit
-                error: String::new(),
-            }
-        })?;
-        Ok(helix::Response {
-            data: response, // FIXME: This should be a bit better...
-            pagination: <_>::default(),
-            request,
-        })
-    }
-
-    fn parse_inner_response(
-        _: Option<Self>,
-        _: &http::Uri,
-        _: &str,
-        _: http::StatusCode,
+        response: &str,
+        status: http::StatusCode,
     ) -> Result<helix::Response<Self, Self::Response>, helix::HelixRequestPostError>
     where
         Self: Sized,
     {
-        unimplemented!("Create User Follows does not implement `parse_inner_response`")
+        Ok(helix::Response {
+            data: match status {
+                http::StatusCode::NO_CONTENT | http::StatusCode::OK => CreateUserFollows::Success,
+                // FIXME: Twitch docs says 204 is success...
+                _ => {
+                    return Err(helix::HelixRequestPostError::InvalidResponse {
+                        reason: "unexpected status code",
+                        response: response.to_string(),
+                        status,
+                        uri: uri.clone(),
+                    })
+                }
+            },
+            pagination: None,
+            request,
+        })
     }
 }
 

--- a/src/helix/users/delete_user_follows.rs
+++ b/src/helix/users/delete_user_follows.rs
@@ -33,13 +33,13 @@
 //! let request = delete_user_follows::DeleteUserFollowsRequest::builder()
 //!     .from_id("1234").to_id("4321")
 //!     .build();
-//! let response: delete_user_follows::DeleteUserFollow = client.req_delete(request, &token).await?;
+//! let response: delete_user_follows::DeleteUserFollow = client.req_delete(request, &token).await?.data;
 //! # Ok(())
 //! # }
 //! ```
 //!
 //! You can also get the [`http::Request`] with [`request.create_request(&token, &client_id)`](helix::RequestDelete::create_request)
-//! and parse the [`http::Response`] with [`DeleteUserFollowsRequest::parse_response(&request.get_uri(), response)`](DeleteUserFollowsRequest::parse_response)
+//! and parse the [`http::Response`] with [`DeleteUserFollowsRequest::parse_response(None, &request.get_uri(), response)`](DeleteUserFollowsRequest::parse_response)
 
 use super::*;
 use helix::RequestDelete;
@@ -123,5 +123,5 @@ fn test_request() {
         "https://api.twitch.tv/helix/users/follows?from_id=41245071&to_id=41245072"
     );
 
-    dbg!(DeleteUserFollowsRequest::parse_response(&uri, http_response).unwrap());
+    dbg!(DeleteUserFollowsRequest::parse_response(Some(req), &uri, http_response).unwrap());
 }

--- a/src/helix/users/unblock_user.rs
+++ b/src/helix/users/unblock_user.rs
@@ -29,13 +29,13 @@
 //! let request = unblock_user::UnblockUserRequest::builder()
 //!     .target_user_id("1234")
 //!     .build();
-//! let response: unblock_user::UnblockUser = client.req_delete(request, &token).await?;
+//! let response: unblock_user::UnblockUser = client.req_delete(request, &token).await?.data;
 //! # Ok(())
 //! # }
 //! ```
 //!
 //! You can also get the [`http::Request`] with [`request.create_request(&token, &client_id)`](helix::RequestDelete::create_request)
-//! and parse the [`http::Response`] with [`UnblockUserRequest::parse_response(&request.get_uri(), response)`](UnblockUserRequest::parse_response)
+//! and parse the [`http::Response`] with [`UnblockUserRequest::parse_response(None, &request.get_uri(), response)`](UnblockUserRequest::parse_response)
 
 use super::*;
 use helix::RequestDelete;
@@ -115,5 +115,5 @@ fn test_request() {
         "https://api.twitch.tv/helix/users/blocks?target_user_id=41245071"
     );
 
-    dbg!(UnblockUserRequest::parse_response(&uri, http_response).unwrap());
+    dbg!(UnblockUserRequest::parse_response(Some(req), &uri, http_response).unwrap());
 }

--- a/src/helix/videos/delete_videos.rs
+++ b/src/helix/videos/delete_videos.rs
@@ -29,13 +29,13 @@
 //! let request = delete_videos::DeleteVideosRequest::builder()
 //!     .id(vec!["1234".to_string()])
 //!     .build();
-//! let response: delete_videos::DeleteVideo = client.req_delete(request, &token).await?;
+//! let response: delete_videos::DeleteVideo = client.req_delete(request, &token).await?.data;
 //! # Ok(())
 //! # }
 //! ```
 //!
 //! You can also get the [`http::Request`] with [`request.create_request(&token, &client_id)`](helix::RequestDelete::create_request)
-//! and parse the [`http::Response`] with [`DeleteVideosRequest::parse_response(&request.get_uri(), response)`](DeleteVideosRequest::parse_response)
+//! and parse the [`http::Response`] with [`DeleteVideosRequest::parse_response(None, &request.get_uri(), response)`](DeleteVideosRequest::parse_response)
 
 use super::*;
 use helix::RequestDelete;
@@ -82,7 +82,7 @@ impl RequestDelete for DeleteVideosRequest {
         Self: Sized,
     {
         match status {
-            http::StatusCode::NO_CONTENT => Ok(helix::Response {
+            http::StatusCode::NO_CONTENT | http::StatusCode::OK => Ok(helix::Response {
                 data: DeleteVideo::Success,
                 pagination: None,
                 request,
@@ -115,5 +115,5 @@ fn test_request() {
         "https://api.twitch.tv/helix/videos?id=234482848"
     );
 
-    dbg!(DeleteVideosRequest::parse_response(&uri, http_response).unwrap());
+    dbg!(DeleteVideosRequest::parse_response(Some(req), &uri, http_response).unwrap());
 }


### PR DESCRIPTION
- refactor Delete and Put
- remove specific error enum variants since they are never hit
- improve error messages

this changes a lot, in particular, removes some variants because of parse_response catching almost all of it. So far, I have not observed an error catched by `*::InvalidResponse` (except when twitch returns 200 instead of 204).

fixes #126