### PR TITLE
fix(helix/points): accept OK as valid DELETE status code

### DIFF
--- a/src/helix/points/delete_custom_reward.rs
+++ b/src/helix/points/delete_custom_reward.rs
@@ -87,7 +87,8 @@ impl RequestDelete for DeleteCustomRewardRequest {
         Self: Sized,
     {
         match status {
-            http::StatusCode::NO_CONTENT => Ok(helix::Response {
+            // FIXME: I've seen OK as the status code
+            http::StatusCode::NO_CONTENT | http::StatusCode::OK => Ok(helix::Response {
                 data: DeleteCustomReward::Success,
                 pagination: None,
                 request,


### PR DESCRIPTION
As with the helix-eventsub delete request, Twitch seems to return 200 OK. I haven't tested the other `DELETE` endpoints but I'd expect similar results.