### PR TITLE
Fix redemption incorrect id type

### DIFF
--- a/src/eventsub/channel/channel_points_custom_reward_redemption/add.rs
+++ b/src/eventsub/channel/channel_points_custom_reward_redemption/add.rs
@@ -37,7 +37,7 @@ pub struct ChannelPointsCustomRewardRedemptionAddV1Payload {
     /// The requested broadcaster display name.
     pub broadcaster_user_name: types::DisplayName,
     /// The redemption identifier.
-    pub id: types::RewardId,
+    pub id: types::RedemptionId,
     /// RFC3339 timestamp of when the reward was redeemed.
     pub redeemed_at: types::Timestamp,
     /// Basic information about the reward that was redeemed, at the time it was redeemed.

--- a/src/eventsub/channel/channel_points_custom_reward_redemption/update.rs
+++ b/src/eventsub/channel/channel_points_custom_reward_redemption/update.rs
@@ -36,7 +36,7 @@ pub struct ChannelPointsCustomRewardRedemptionUpdateV1Payload {
     /// The requested broadcaster display name.
     pub broadcaster_user_name: types::DisplayName,
     /// The redemption identifier.
-    pub id: types::RewardId,
+    pub id: types::RedemptionId,
     /// RFC3339 timestamp of when the reward was redeemed.
     pub redeemed_at: types::Timestamp,
     /// Basic information about the reward that was redeemed, at the time it was redeemed.


### PR DESCRIPTION
Small fix: redemption id has the wrong type in eventsub payloads.