### PR TITLE
feat(pubsub): enable/add unlisten_command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * Added `user.authorization.grant` to EventSub
 * Added `helix::make_stream` to make streams out of paginated responses.
 * Added fields `moderator_id`,`moderator_login`,`moderator_name` and `reason` to `BannedUser`
+* Added `pubsub::unlisten_command`
 
 ### Changed
 
@@ -42,6 +43,7 @@
 * `HelixClient` methods `search_categories`, `search_channels`, `get_followed_streams` and `get_moderators_in_channel_from_id` now use streams to provide paginated response. 
 * Renamed `BroadcasterType::Affiliated` -> `BroadcasterType::Affiliate`
 * Client extension methods that are paginated are now paginated lazily using a stream.
+* `pubsub::listen_command` now accepts `Into<Option<&str>>` as the `auth_token`.
 
 ### Removed
 

--- a/src/pubsub/mod.rs
+++ b/src/pubsub/mod.rs
@@ -661,4 +661,22 @@ mod tests {
         let actual = Response::parse(source).unwrap();
         assert_eq!(expected, actual);
     }
+
+    #[test]
+    fn listen() {
+        let topic =
+            Topics::ChannelBitsEventsV2(channel_bits::ChannelBitsEventsV2 { channel_id: 12345 });
+        let expected = r#"{"type":"LISTEN","nonce":"my nonce","data":{"topics":["channel-bits-events-v2.12345"],"auth_token":"my token"}}"#;
+        let actual = listen_command(&[topic], "my token", "my nonce").expect("should serialize");
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn unlisten() {
+        let topic =
+            Topics::ChannelBitsEventsV2(channel_bits::ChannelBitsEventsV2 { channel_id: 12345 });
+        let expected = r#"{"type":"UNLISTEN","nonce":"my nonce","data":{"topics":["channel-bits-events-v2.12345"]}}"#;
+        let actual = unlisten_command(&[topic], "my nonce").expect("should serialize");
+        assert_eq!(expected, actual);
+    }
 }

--- a/src/pubsub/mod.rs
+++ b/src/pubsub/mod.rs
@@ -268,13 +268,14 @@ struct ITopicSubscribe<'a> {
 /// // To parse the websocket messages, use pubsub::Response::parse
 /// # fn send_command(command: String) -> Result<(),()> {Ok(())}
 /// ```
-pub fn listen_command<'t, O>(
+pub fn listen_command<'t, T, N>(
     topics: &'t [Topics],
-    auth_token: &'t str,
-    nonce: O,
+    auth_token: T,
+    nonce: N,
 ) -> Result<String, serde_json::Error>
 where
-    O: Into<Option<&'t str>>,
+    T: Into<Option<&'t str>>,
+    N: Into<Option<&'t str>>,
 {
     let topics = topics.iter().map(|t| t.to_string()).collect::<Vec<_>>();
     serde_json::to_string(&ITopicSubscribe {
@@ -282,7 +283,7 @@ where
         nonce: nonce.into(),
         data: ITopicSubscribeData {
             topics: &topics,
-            auth_token: Some(auth_token),
+            auth_token: auth_token.into(),
         },
     })
 }

--- a/src/pubsub/mod.rs
+++ b/src/pubsub/mod.rs
@@ -289,6 +289,7 @@ where
 }
 
 /// Create a unlisten command.
+///
 /// # Example
 ///
 /// Unlisten from moderator actions and follows

--- a/src/pubsub/mod.rs
+++ b/src/pubsub/mod.rs
@@ -226,7 +226,8 @@ impl std::fmt::Display for Topics {
 #[derive(Serialize)]
 struct ITopicSubscribeData<'a> {
     topics: &'a [String],
-    auth_token: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    auth_token: Option<&'a str>,
 }
 #[derive(Serialize)]
 struct ITopicSubscribe<'a> {
@@ -281,7 +282,7 @@ where
         nonce: nonce.into(),
         data: ITopicSubscribeData {
             topics: &topics,
-            auth_token,
+            auth_token: Some(auth_token),
         },
     })
 }


### PR DESCRIPTION
This PR adds (or rather enables) the unlisten command for pubsub and tests.

This is a WIP because I'm not really sure if the `auth_token` should be included in the command as the docs are really vague about it.

* Chatterino _doesn't_ include the `auth_token` ([permalink](https://github.com/Chatterino/chatterino2/blob/master/src/providers/twitch/PubsubHelpers.cpp#L82-L104)).

* `go-twitch-pubsub` _doesn't_ include the `auth_token` ([permalink](https://github.com/tracy-and-matt/go-twitch-pubsub/blob/2db33baf9ef0ed7373e2712912102f4775a80fbd/pubsub.go#L342-L353))

* Twitch4j _does_ include the `auth_token` (if I understand the code correctly):
  1. [Includes the data](https://github.com/twitch4j/twitch4j/blob/f291fb5b0e8f4b2032437c97d09f4aa7e11d8059/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java#L796)
  2. [`data` is defined as _some_ json object](https://github.com/twitch4j/twitch4j/blob/f291fb5b0e8f4b2032437c97d09f4aa7e11d8059/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/PubSubRequest.java#L32)
  3. [`auth_token` is put in `data`](https://github.com/twitch4j/twitch4j/blob/f291fb5b0e8f4b2032437c97d09f4aa7e11d8059/pubsub/src/main/java/com/github/twitch4j/pubsub/ITwitchPubSub.java#L47)
 
