### PR TITLE
feat(pubsub): implement `Clone` and `Hash` for topics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 * Renamed `BroadcasterType::Affiliated` -> `BroadcasterType::Affiliate`
 * Client extension methods that are paginated are now paginated lazily using a stream.
 * `pubsub::listen_command` now accepts `Into<Option<&str>>` as the `auth_token`.
+* `pubsub::Topics` and all topics now implement `Clone` and `Hash`.
 
 ### Removed
 

--- a/src/pubsub/automod_queue.rs
+++ b/src/pubsub/automod_queue.rs
@@ -3,7 +3,7 @@ use crate::{pubsub, types};
 use serde::{Deserialize, Serialize};
 
 /// A user follows the channel
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[serde(into = "String", try_from = "String")]
 pub struct AutoModQueue {
     /// The currently authenticated moderator

--- a/src/pubsub/channel_bits.rs
+++ b/src/pubsub/channel_bits.rs
@@ -5,7 +5,7 @@ use crate::{pubsub, types};
 use serde::{Deserialize, Serialize};
 
 /// Anyone cheers in a specified channel.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Hash)]
 #[serde(into = "String", try_from = "String")]
 pub struct ChannelBitsEventsV2 {
     /// The channel_id to watch. Can be fetched with the [Get Users](crate::helix::users::get_users) endpoint

--- a/src/pubsub/channel_bits_badge.rs
+++ b/src/pubsub/channel_bits_badge.rs
@@ -4,7 +4,7 @@ use crate::{pubsub, types};
 use serde::{Deserialize, Serialize};
 
 /// Anyone shares a bit badge in a specified channel.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Hash)]
 #[serde(into = "String", try_from = "String")]
 pub struct ChannelBitsBadgeUnlocks {
     /// The channel_id to watch. Can be fetched with the [Get Users](crate::helix::users::get_users) endpoint

--- a/src/pubsub/channel_cheer.rs
+++ b/src/pubsub/channel_cheer.rs
@@ -5,7 +5,7 @@ use crate::{pubsub, types};
 use serde::{Deserialize, Serialize};
 
 /// A user redeems a cheer with shared rewards.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[serde(into = "String", try_from = "String")]
 pub struct ChannelCheerEventsPublicV1 {
     /// The channel_id to watch. Can be fetched with the [Get Users](crate::helix::users::get_users) endpoint

--- a/src/pubsub/channel_points.rs
+++ b/src/pubsub/channel_points.rs
@@ -5,7 +5,7 @@ use crate::{pubsub, types};
 use serde::{Deserialize, Serialize};
 
 /// A user redeems an reward using channel points.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[serde(into = "String", try_from = "String")]
 pub struct ChannelPointsChannelV1 {
     /// The channel_id to watch. Can be fetched with the [Get Users](crate::helix::users::get_users) endpoint

--- a/src/pubsub/channel_sub_gifts.rs
+++ b/src/pubsub/channel_sub_gifts.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 /// A user gifts subs.
 ///
 /// This allows one to know how many subs were gifted in a single event. See also [`pubsub::channel_subscriptions::ChannelSubscribeEventsV1`] which needs token from broadcaster
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[serde(into = "String", try_from = "String")]
 pub struct ChannelSubGiftsV1 {
     /// The channel_id to watch. Can be fetched with the [Get Users](crate::helix::users::get_users) endpoint

--- a/src/pubsub/channel_subscriptions.rs
+++ b/src/pubsub/channel_subscriptions.rs
@@ -6,7 +6,7 @@ use crate::{pubsub, types};
 use serde::{Deserialize, Serialize};
 
 /// A subscription event happens in channel
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[serde(into = "String", try_from = "String")]
 pub struct ChannelSubscribeEventsV1 {
     /// The channel_id to watch. Can be fetched with the [Get Users](crate::helix::users::get_users) endpoint

--- a/src/pubsub/community_points.rs
+++ b/src/pubsub/community_points.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 /// A user redeems an reward using channel points.
 ///
 /// Reply is [`pubsub::channel_points::ChannelPointsChannelV1Reply`]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[serde(into = "String", try_from = "String")]
 pub struct CommunityPointsChannelV1 {
     /// The channel_id to watch. Can be fetched with the [Get Users](crate::helix::users::get_users) endpoint

--- a/src/pubsub/following.rs
+++ b/src/pubsub/following.rs
@@ -5,7 +5,7 @@ use crate::{pubsub, types};
 use serde::{Deserialize, Serialize};
 
 /// A user follows the channel
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[serde(into = "String", try_from = "String")]
 pub struct Following {
     /// The channel_id to watch. Can be fetched with the [Get Users](crate::helix::users::get_users) endpoint

--- a/src/pubsub/hypetrain.rs
+++ b/src/pubsub/hypetrain.rs
@@ -4,7 +4,7 @@ use crate::{pubsub, types};
 use serde::{Deserialize, Serialize};
 
 /// A user redeems an reward using channel points.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
 #[serde(into = "String", try_from = "String")]
 pub struct HypeTrainEventsV1 {
@@ -26,7 +26,7 @@ impl pubsub::Topic for HypeTrainEventsV1 {
 }
 
 /// A user redeems an reward using channel points.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
 #[serde(into = "String", try_from = "String")]
 pub struct HypeTrainEventsV1Rewards {

--- a/src/pubsub/mod.rs
+++ b/src/pubsub/mod.rs
@@ -133,7 +133,7 @@ pub trait Topic: Serialize + Into<String> {
 }
 
 /// All possible topics
-#[derive(Deserialize, Serialize, PartialEq, Eq, Debug, Clone)]
+#[derive(Deserialize, Serialize, PartialEq, Eq, Debug, Clone, Hash)]
 #[serde(untagged)]
 #[non_exhaustive]
 pub enum Topics {

--- a/src/pubsub/mod.rs
+++ b/src/pubsub/mod.rs
@@ -133,7 +133,7 @@ pub trait Topic: Serialize + Into<String> {
 }
 
 /// All possible topics
-#[derive(Deserialize, Serialize, PartialEq, Eq, Debug)]
+#[derive(Deserialize, Serialize, PartialEq, Eq, Debug, Clone)]
 #[serde(untagged)]
 #[non_exhaustive]
 pub enum Topics {

--- a/src/pubsub/moderation.rs
+++ b/src/pubsub/moderation.rs
@@ -6,7 +6,7 @@ use crate::{pubsub, types};
 use serde::{Deserialize, Serialize};
 
 /// A moderator performs an action in the channel.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Hash)]
 #[serde(into = "String", try_from = "String")]
 pub struct ChatModeratorActions {
     /// The user_id to listen as. Can be fetched with the [Get Users](crate::helix::users::get_users) endpoint

--- a/src/pubsub/raid.rs
+++ b/src/pubsub/raid.rs
@@ -4,7 +4,7 @@ use crate::{pubsub, types};
 use serde::{Deserialize, Serialize};
 
 /// A user raids the channel
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[serde(into = "String", try_from = "String")]
 pub struct Raid {
     /// The channel_id to watch. Can be fetched with the [Get Users](crate::helix::users::get_users) endpoint

--- a/src/pubsub/user_moderation_notifications.rs
+++ b/src/pubsub/user_moderation_notifications.rs
@@ -3,7 +3,7 @@ use crate::{pubsub, types};
 use serde::{Deserialize, Serialize};
 
 /// A user follows the channel
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[serde(into = "String", try_from = "String")]
 pub struct UserModerationNotifications {
     /// The currently authenticated user for whose automod messages will be reported on

--- a/src/pubsub/video_playback.rs
+++ b/src/pubsub/video_playback.rs
@@ -9,7 +9,7 @@ use crate::{pubsub, types};
 use serde::{Deserialize, Serialize};
 
 /// Statistics about stream
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Hash)]
 #[serde(into = "String", try_from = "String")]
 pub struct VideoPlayback {
     /// The channel_login to watch.
@@ -26,7 +26,7 @@ impl pubsub::Topic for VideoPlayback {
 }
 
 /// Statistics about stream
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Hash)]
 #[serde(into = "String", try_from = "String")]
 pub struct VideoPlaybackById {
     /// The channel_login to watch.


### PR DESCRIPTION
This PR implements
* `Clone` for the `Topics` enum (all subtopics already implement `Clone`)
* `Hash` for all topics