### PR TITLE
implement mocking

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,4 +3,5 @@
     "rust-analyzer.checkOnSave.features": ["all", "unsupported", "twitch_oauth2/reqwest_client", "twitch_oauth2/surf_client", "deny_unknown_fields", "surf/curl-client"],
     "rust-analyzer.checkOnSave.enable": true,
     "rust-analyzer.cargo.features": ["all", "unsupported", "deny_unknown_fields"],
+    "rust-analyzer.experimental.procAttrMacros": true,
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 * Added `EmoteUrlBuilder` to make an url with `EmoteId::url()`
 * Added methods to `Timestamp` for constructing and handling them. Can use the `chrono` crate behind the `chrono` feature.
 * New `HelixClient` method `get_follow_relationships` for getting follows.
+* `twitch_oauth2` has been upgraded, and following this upgrade, `HelixClient`, `TmiClient` and `TwitchClient` can be used as clients for token requests.
 
 ### Changed
 
@@ -49,7 +50,7 @@
 * Client extension methods that are paginated are now paginated lazily using a stream.
 * `pubsub::listen_command` now accepts `Into<Option<&str>>` as the `auth_token`.
 * `pubsub::Topics` and all topics now implement `Clone` and `Hash`.
-
+* `TWITCH_HELIX_URL`, `TWITCH_TMI_URL` and `TWITCH_PUBSUB_URL` are now `url::Url`s and can be overridden with environment variables. See the docs for more information.
 ### Removed
 
 * Removed enum variants for a lot of error states in helix endpoint responses. Most of these are returned by `HelixRequest_Error::Error`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1994,7 +1994,7 @@ dependencies = [
 
 [[package]]
 name = "twitch_oauth2"
-version = "0.6.0-rc.1"
+version = "0.6.0-rc.2"
 dependencies = [
  "aliri_braid",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1972,6 +1972,7 @@ dependencies = [
  "hmac 0.11.0",
  "http",
  "http-types",
+ "once_cell",
  "reqwest",
  "serde",
  "serde_cbor",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -987,9 +987,9 @@ checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "js-sys"
-version = "0.3.51"
+version = "0.3.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83bdfbace3a0e81a4253f73b49e960b053e396a11012cbd49b9b74d6a2b67062"
+checksum = "ce791b7ca6638aae45be056e068fc756d871eb3b3b10b8efa62d1c9cec616752"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1993,7 +1993,7 @@ dependencies = [
 
 [[package]]
 name = "twitch_oauth2"
-version = "0.5.2"
+version = "0.6.0-rc.1"
 dependencies = [
  "aliri_braid",
  "async-trait",
@@ -2137,9 +2137,9 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.74"
+version = "0.2.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54ee1d4ed486f78874278e63e4069fc1ab9f6a18ca492076ffb90c5eb2997fd"
+checksum = "b608ecc8f4198fe8680e2ed18eccab5f0cd4caaf3d83516fa5fb2e927fda2586"
 dependencies = [
  "cfg-if",
  "serde",
@@ -2149,9 +2149,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.74"
+version = "0.2.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b33f6a0694ccfea53d94db8b2ed1c3a8a4c86dd936b13b9f0a15ec4a451b900"
+checksum = "580aa3a91a63d23aac5b6b267e2d13cb4f363e31dce6c352fca4752ae12e479f"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -2164,9 +2164,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.24"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fba7978c679d53ce2d0ac80c8c175840feb849a161664365d1287b41f2e67f1"
+checksum = "16646b21c3add8e13fdb8f20172f8a28c3dbf62f45406bcff0233188226cfe0c"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -2176,9 +2176,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.74"
+version = "0.2.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "088169ca61430fe1e58b8096c24975251700e7b1f6fd91cc9d59b04fb9b18bd4"
+checksum = "171ebf0ed9e1458810dfcb31f2e766ad6b3a89dbda42d8901f2b268277e5f09c"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2186,9 +2186,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.74"
+version = "0.2.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be2241542ff3d9f241f5e2cb6dd09b37efe786df8851c54957683a49f0987a97"
+checksum = "6c2657dd393f03aa2a659c25c6ae18a13a4048cebd220e147933ea837efc589f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2199,15 +2199,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.74"
+version = "0.2.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7cff876b8f18eed75a66cf49b65e7f967cb354a7aa16003fb55dbfd25b44b4f"
+checksum = "2e0c4a743a309662d45f4ede961d7afa4ba4131a59a639f29b0069c3798bbcc2"
 
 [[package]]
 name = "web-sys"
-version = "0.3.51"
+version = "0.3.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e828417b379f3df7111d3a2a9e5753706cae29c41f7c4029ee9fd77f3e09e582"
+checksum = "01c70a82d842c9979078c772d4a1344685045f1a5628f677c2b2eab4dd7d2696"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ displaydoc = "0.2.3"
 http = "0.2.4"
 typed-builder = { version = "0.9.0", optional = true }
 url = { version = "2.2.2", optional = true }
-twitch_oauth2 = { version = "0.5.0", optional = true, path = "twitch_oauth2/" }
+twitch_oauth2 = { version = "0.6.0-rc.1", optional = true, path = "twitch_oauth2/" }
 serde = { version = "1.0.127", features = ["derive"] }
 serde_derive = "1.0.127"
 serde_path_to_error = { version = "0.1.4", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -145,5 +145,10 @@ name = "followed_streams"
 path = "examples/followed_streams.rs"
 required-features = ["reqwest_client", "helix"]
 
+[[example]]
+name = "mock_api"
+path = "examples/mock_api.rs"
+required-features = ["reqwest_client", "helix"]
+
 [package.metadata.docs.rs]
 features = ["all", "unsupported"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,8 @@ thiserror = "1.0.26"
 displaydoc = "0.2.3"
 http = "0.2.4"
 typed-builder = { version = "0.9.0", optional = true }
-url = { version = "2.2.2", optional = true }
+url = "2.2.2"
+once_cell = "1.8.0"
 twitch_oauth2 = { version = "0.6.0-rc.1", optional = true, path = "twitch_oauth2/" }
 serde = { version = "1.0.127", features = ["derive"] }
 serde_derive = "1.0.127"
@@ -46,7 +47,6 @@ deny_unknown_fields = []
 trace_unknown_fields = ["serde_ignored", "tracing"]
 
 helix = [
-    "url",
     "async-trait",
     "serde_json",
     "serde_path_to_error",
@@ -57,7 +57,6 @@ tmi = ["serde_json", "serde_path_to_error"]
 
 surf_client = [
     "surf",
-    "url",
     "http-types",
     "client",
     "twitch_oauth2/surf_client",
@@ -70,6 +69,8 @@ pubsub = ["serde_json", "serde_path_to_error"]
 eventsub = ["serde_json", "serde_path_to_error"]
 
 hmac = ["crypto_hmac", "sha2"]
+
+mock_api = []
 
 all = [
     "tmi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ http = "0.2.4"
 typed-builder = { version = "0.9.0", optional = true }
 url = "2.2.2"
 once_cell = "1.8.0"
-twitch_oauth2 = { version = "0.6.0-rc.1", optional = true, path = "twitch_oauth2/" }
+twitch_oauth2 = { version = "0.6.0-rc.2", optional = true, path = "twitch_oauth2/" }
 serde = { version = "1.0.127", features = ["derive"] }
 serde_derive = "1.0.127"
 serde_path_to_error = { version = "0.1.4", optional = true }

--- a/examples/automod_check.rs
+++ b/examples/automod_check.rs
@@ -7,7 +7,7 @@ fn main() {
         println!("Error: {}", err);
         let mut e: &'_ dyn Error = err.as_ref();
         while let Some(cause) = e.source() {
-            println!("Caused by: {:?}", cause);
+            println!("Caused by: {}", cause);
             e = cause;
         }
     }

--- a/examples/channel_information.rs
+++ b/examples/channel_information.rs
@@ -7,7 +7,7 @@ fn main() {
         println!("Error: {}", err);
         let mut e: &'_ dyn Error = err.as_ref();
         while let Some(cause) = e.source() {
-            println!("Caused by: {:?}", cause);
+            println!("Caused by: {}", cause);
             e = cause;
         }
     }
@@ -23,9 +23,7 @@ async fn run() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>>
         .or_else(|| args.next())
         .map(AccessToken::new)
         .expect("Please set env: TWITCH_TOKEN or pass token as first argument");
-    let token = UserToken::from_existing(&client, token, None, None)
-        .await
-        .unwrap();
+    let token = UserToken::from_existing(&client, token, None, None).await?;
 
     let user = client
         .get_user_from_login(args.next().unwrap(), &token)

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -6,7 +6,7 @@ fn main() {
         println!("Error: {}", err);
         let mut e: &'_ dyn Error = err.as_ref();
         while let Some(cause) = e.source() {
-            println!("Caused by: {:?}", cause);
+            println!("Caused by: {}", cause);
             e = cause;
         }
     }

--- a/examples/followed_streams.rs
+++ b/examples/followed_streams.rs
@@ -8,7 +8,7 @@ fn main() {
         println!("Error: {}", err);
         let mut e: &'_ dyn Error = err.as_ref();
         while let Some(cause) = e.source() {
-            println!("Caused by: {:?}", cause);
+            println!("Caused by: {}", cause);
             e = cause;
         }
     }

--- a/examples/get_channel_status.rs
+++ b/examples/get_channel_status.rs
@@ -7,7 +7,7 @@ fn main() {
         println!("Error: {}", err);
         let mut e: &'_ dyn Error = err.as_ref();
         while let Some(cause) = e.source() {
-            println!("Caused by: {:?}", cause);
+            println!("Caused by: {}", cause);
             e = cause;
         }
     }

--- a/examples/get_moderation.rs
+++ b/examples/get_moderation.rs
@@ -11,7 +11,7 @@ fn main() {
         println!("Error: {}", err);
         let mut e: &'_ dyn Error = err.as_ref();
         while let Some(cause) = e.source() {
-            println!("Caused by: {:?}", cause);
+            println!("Caused by: {}", cause);
             e = cause;
         }
     }

--- a/examples/mock_api.rs
+++ b/examples/mock_api.rs
@@ -1,0 +1,159 @@
+use futures::TryStreamExt;
+use twitch_api2::types;
+use twitch_api2::HelixClient;
+use twitch_oauth2::Scope;
+fn main() {
+    use std::error::Error;
+    if let Err(err) = run() {
+        println!("Error: {}", err);
+        let mut e: &'_ dyn Error = err.as_ref();
+        while let Some(cause) = e.source() {
+            println!("Caused by: {}", cause);
+            e = cause;
+        }
+    }
+}
+
+#[tokio::main]
+async fn run() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+    let _ = dotenv::dotenv(); // Eat error
+
+    let client: HelixClient<reqwest::Client> = HelixClient::default();
+
+    let mut args = std::env::args().skip(1);
+    std::env::var("TWITCH_OAUTH2_URL")
+        .ok()
+        .or_else(|| args.next())
+        .map(|t| std::env::set_var("TWITCH_OAUTH2_URL", &t))
+        .expect("Please set env: TWITCH_OAUTH2_URL or pass url as first argument");
+
+    let client_id = std::env::var("MOCK_CLIENT_ID")
+        .ok()
+        .or_else(|| args.next())
+        .map(twitch_oauth2::ClientId::new)
+        .expect("Please set env: MOCK_CLIENT_ID or pass client id as an argument");
+
+    let client_secret = std::env::var("MOCK_CLIENT_SECRET")
+        .ok()
+        .or_else(|| args.next())
+        .map(twitch_oauth2::ClientSecret::new)
+        .expect("Please set env: MOCK_CLIENT_SECRET or pass client secret as an argument");
+
+    let user_id = std::env::var("MOCK_USER_ID")
+        .ok()
+        .or_else(|| args.next())
+        .map(types::UserId::new)
+        .expect("Please set env: MOCK_USER_ID or pass user_id as an argument");
+
+    let token = twitch_oauth2::UserToken::mock_token(
+        &client,
+        None,
+        client_id,
+        client_secret,
+        &user_id,
+        vec![Scope::ModerationRead],
+    )
+    .await?;
+
+    let user = client
+        .get_user_from_id(&*user_id, &token)
+        .await?
+        .expect("no user found");
+
+    let _channel = client
+        .get_channel_from_id(&*user_id, &token)
+        .await?
+        .expect("no channel found");
+    let _channel = client
+        .get_channel_from_id(user.id.clone(), &token)
+        .await?
+        .expect("no channel found");
+
+    let _s: Vec<_> = client
+        .search_categories("test", &token)
+        .try_collect()
+        .await?;
+    let _s: Vec<_> = client
+        .search_channels("test", true, &token)
+        .try_collect()
+        .await?;
+    let search: Vec<_> = client
+        .search_channels("test", false, &token)
+        .try_collect()
+        .await?;
+    let _total = client
+        .get_total_followers_from_id(search.get(0).unwrap().id.clone(), &token)
+        .await?;
+    moderation(&client, &user_id, &token).await?;
+    Ok(())
+}
+
+pub async fn moderation<'a, C: twitch_api2::HttpClient<'a> + Sync>(
+    client: &'a twitch_api2::HelixClient<'a, C>,
+    broadcaster_id: &'a types::UserIdRef,
+    token: &'a twitch_oauth2::UserToken,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+    use twitch_api2::helix::moderation::*;
+    println!("====Moderators====");
+    println!(
+        "{:?}",
+        client
+            .get_moderators_in_channel_from_id(broadcaster_id, token)
+            .try_collect::<Vec<_>>()
+            .await?,
+    );
+
+    println!("====Last 20 Moderator Events====");
+    let moderator_events_req = GetModeratorEventsRequest::builder()
+        .broadcaster_id(broadcaster_id)
+        .build();
+
+    let mut response = client.req_get(moderator_events_req, token).await?;
+    println!("{:?}", response.data);
+
+    // /mod and /unmod events
+    while let Ok(Some(new_response)) = response.get_next(client, token).await {
+        response = new_response;
+        println!("{:?}", response.data);
+    }
+
+    println!("====Banned users====");
+    let banned_users_req = GetBannedUsersRequest::builder()
+        .broadcaster_id(broadcaster_id)
+        .build();
+    let mut response = client.req_get(banned_users_req, token).await?;
+    println!(
+        "{:?}",
+        response
+            .data
+            .iter()
+            .map(|user| &user.user_name)
+            .collect::<Vec<_>>()
+    );
+
+    while let Ok(Some(new_response)) = response.get_next(client, token).await {
+        response = new_response;
+        println!(
+            "{:?}",
+            response
+                .data
+                .iter()
+                .map(|user| &user.user_name)
+                .collect::<Vec<_>>()
+        );
+    }
+
+    println!("====Last 10 Banned Events====");
+    let banned_events_req = GetBannedEventsRequest::builder()
+        .broadcaster_id(broadcaster_id)
+        .first(Some(10))
+        .build();
+    let mut response = client.req_get(banned_events_req, token).await?;
+    println!("{:?}", response.data);
+
+    while let Ok(Some(new_response)) = response.get_next(client, token).await {
+        response = new_response;
+        println!("{:?}", response.data);
+    }
+    Ok(())
+}

--- a/examples/modify_channel.rs
+++ b/examples/modify_channel.rs
@@ -7,7 +7,7 @@ fn main() {
         println!("Error: {}", err);
         let mut e: &'_ dyn Error = err.as_ref();
         while let Some(cause) = e.source() {
-            println!("Caused by: {:?}", cause);
+            println!("Caused by: {}", cause);
             e = cause;
         }
     }

--- a/src/helix/client_ext.rs
+++ b/src/helix/client_ext.rs
@@ -586,8 +586,8 @@ where
                         Some((Ok(d), state))
                     }
                 } else {
-                    // We've taken all the entries, but not returned a proper request. This is a bug
-                    panic!("exhausted the deq without handling a new response")
+                    // New request returned empty.
+                    None
                 }
             }
             StateMode::Next(Some(_)) => {

--- a/src/helix/search/search_channels.rs
+++ b/src/helix/search/search_channels.rs
@@ -86,7 +86,11 @@ pub struct Channel {
     /// Live status
     pub is_live: bool,
     /// UTC timestamp. (live only)
-    pub started_at: types::Timestamp,
+    #[serde(
+        default,
+        deserialize_with = "helix::deserialize_none_from_empty_string"
+    )]
+    pub started_at: Option<types::Timestamp>,
     // FIXME: Twitch doc say tag_ids
     /// Shows tag IDs that apply to the stream (live only).See <https://www.twitch.tv/directory/all/tags> for tag types
     pub tag_ids: Vec<types::TagId>,

--- a/src/helix/webhooks/topics/mod.rs
+++ b/src/helix/webhooks/topics/mod.rs
@@ -34,23 +34,20 @@ pub trait Topic: DeserializeOwned + Serialize + PartialEq {
     /// Returns full URI for the request, including query parameters.
     fn get_uri(&self) -> Result<http::Uri, helix::InvalidUri> {
         use std::str::FromStr;
-        http::Uri::from_str(&format!(
-            "{}{}?{}",
-            crate::TWITCH_HELIX_URL,
-            <Self as Topic>::PATH,
-            self.query()?
-        ))
-        .map_err(Into::into)
+        let query = self.query()?;
+        let url = crate::TWITCH_HELIX_URL
+            .join(<Self as Topic>::PATH)
+            .map(|mut u| {
+                u.set_query(Some(&query));
+                u
+            })?;
+        http::Uri::from_str(url.as_str()).map_err(Into::into)
     }
     /// Returns bare URI for the request, NOT including query parameters.
     fn get_bare_uri() -> Result<http::Uri, helix::InvalidUri> {
         use std::str::FromStr;
-        http::Uri::from_str(&format!(
-            "{}{}?",
-            crate::TWITCH_HELIX_URL,
-            <Self as Topic>::PATH,
-        ))
-        .map_err(Into::into)
+        let url = crate::TWITCH_HELIX_URL.join(<Self as Topic>::PATH)?;
+        http::Uri::from_str(url.as_str()).map_err(Into::into)
     }
 
     /// Parse payload received on webhook.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,6 +137,7 @@ pub use client::Client as HttpClient;
 #[cfg(feature = "client")]
 pub use client::DummyHttpClient;
 
+#[cfg(any(feature = "helix", feature = "tmi", feature = "pubsub"))]
 /// Generate a url with a default if `mock_api` feature is disabled, or env var is not defined or is invalid utf8
 macro_rules! mock_env_url {
     ($var:literal, $default:expr $(,)?) => {
@@ -156,7 +157,7 @@ macro_rules! mock_env_url {
 
 /// Location of Twitch Helix
 ///
-/// Can be overriden when feature `mock_api` is enabled with environment variable `TWITCH_HELIX_URL`.
+/// Can be overridden when feature `mock_api` is enabled with environment variable `TWITCH_HELIX_URL`.
 ///
 /// # Examples
 ///

--- a/src/tmi/mod.rs
+++ b/src/tmi/mod.rs
@@ -71,7 +71,7 @@ impl<'a, C: crate::HttpClient<'a>> TmiClient<'a, C> {
     ) -> Result<GetChatters, RequestError<<C as crate::HttpClient<'a>>::Error>> {
         let url = format!(
             "{}{}{}{}",
-            crate::TWITCH_TMI_URL,
+            crate::TWITCH_TMI_URL.as_str(),
             "group/user/",
             broadcaster.as_str().replace('#', "").to_ascii_lowercase(),
             "/chatters"
@@ -103,7 +103,7 @@ impl<'a, C: crate::HttpClient<'a>> TmiClient<'a, C> {
     ) -> Result<GetHosts, RequestError<<C as crate::HttpClient<'a>>::Error>> {
         let url = format!(
             "{}{}{}{}",
-            crate::TWITCH_TMI_URL,
+            crate::TWITCH_TMI_URL.as_str(),
             "hosts?",
             if include_logins {
                 "include_logins=1&"


### PR DESCRIPTION
This aims to bring in twitch-cli to CI and for users. More changes to be done in future prs

Remaining:
- [ ] Add a CI workflow that tries to *warn* on discrepancies between the library and twitch-cli.
- [ ] (this is specific to [twitch_oauth2](github.com/Emilgardis/twitch_oauth2), but use `/auth/validate` if/when available, see https://github.com/twitchdev/twitch-cli/issues/82