### PR TITLE
implement getting other fields in normal responses

### DIFF
--- a/src/helix/bits/get_bits_leaderboard.rs
+++ b/src/helix/bits/get_bits_leaderboard.rs
@@ -155,6 +155,7 @@ impl RequestGet for GetBitsLeaderboardRequest {
             pagination: None,
             request,
             total: Some(response.total),
+            other: None,
         })
     }
 }

--- a/src/helix/channels/get_channel_information.rs
+++ b/src/helix/channels/get_channel_information.rs
@@ -112,6 +112,7 @@ impl RequestGet for GetChannelInformationRequest {
             pagination: response.pagination.cursor,
             request,
             total: None,
+            other: None,
         })
     }
 }

--- a/src/helix/channels/modify_channel_information.rs
+++ b/src/helix/channels/modify_channel_information.rs
@@ -132,6 +132,7 @@ impl RequestPatch for ModifyChannelInformationRequest {
             pagination: None,
             request,
             total: None,
+            other: None,
         })
     }
 }

--- a/src/helix/eventsub/create_eventsub_subscription.rs
+++ b/src/helix/eventsub/create_eventsub_subscription.rs
@@ -175,6 +175,7 @@ impl<E: EventSubscription> helix::RequestPost for CreateEventSubSubscriptionRequ
             request,
             // helix::Response total is generally the total number of results, not what the total for this endpoint means. Thus, we set it to None.
             total: None,
+            other: None,
         })
     }
 }

--- a/src/helix/eventsub/delete_eventsub_subscription.rs
+++ b/src/helix/eventsub/delete_eventsub_subscription.rs
@@ -48,6 +48,7 @@ impl RequestDelete for DeleteEventSubSubscriptionRequest {
                 pagination: None,
                 request,
                 total: None,
+                other: None,
             }),
             _ => Err(helix::HelixRequestDeleteError::InvalidResponse {
                 reason: "unexpected status",

--- a/src/helix/eventsub/get_eventsub_subscriptions.rs
+++ b/src/helix/eventsub/get_eventsub_subscriptions.rs
@@ -99,6 +99,7 @@ impl RequestGet for GetEventSubSubscriptionsRequest {
             pagination: response.pagination.cursor,
             request,
             total: Some(response.total),
+            other: None,
         })
     }
 }

--- a/src/helix/mod.rs
+++ b/src/helix/mod.rs
@@ -129,6 +129,8 @@ struct InnerResponse<D> {
     pagination: Pagination,
     #[serde(default)]
     total: Option<i64>,
+    #[serde(default, flatten)]
+    other: Option<serde_json::Map<String, serde_json::Value>>,
 }
 
 #[derive(Deserialize, Debug)]
@@ -777,6 +779,7 @@ pub trait RequestPost: Request {
             pagination: response.pagination.cursor,
             request,
             total: response.total,
+            other: None,
         })
     }
 }
@@ -1079,6 +1082,7 @@ pub trait RequestGet: Request {
             pagination: response.pagination.cursor,
             request,
             total: response.total,
+            other: response.other,
         })
     }
 }
@@ -1098,6 +1102,10 @@ where
     pub request: Option<R>,
     /// Response would return this many results if fully paginated. Sometimes this is not emmitted or correct for this purpose, in those cases, this value will be `None`.
     pub total: Option<i64>,
+    /// Fields which are not part of the data response, but are returned by the endpoint.
+    ///
+    /// See for example [Get Broadcaster Subscriptions](https://dev.twitch.tv/docs/api/reference#get-broadcaster-subscriptions) which returns this.
+    pub other: Option<serde_json::Map<String, serde_json::Value>>,
 }
 
 impl<R, D> Response<R, D>
@@ -1105,6 +1113,30 @@ where
     R: Request,
     D: serde::de::DeserializeOwned + PartialEq,
 {
+    /// Get a field from the response that is not part of `data`.
+    pub fn get_other<Q, V>(&self, key: &Q) -> Result<Option<V>, serde_json::Error>
+    where
+        String: std::borrow::Borrow<Q>,
+        Q: ?Sized + Ord + Eq + std::hash::Hash,
+        V: serde::de::DeserializeOwned, {
+        use std::borrow::Borrow as _;
+        match &key {
+            total if &String::from("total").borrow() == total => {
+                if let Some(total) = self.total {
+                    let total = serde_json::json!(total);
+                    Some(serde_json::from_value(total)).transpose()
+                } else {
+                    Ok(None)
+                }
+            }
+            _ => self
+                .other
+                .as_ref()
+                .and_then(|map| map.get(key.borrow()))
+                .map(|v| serde_json::from_value(v.clone()))
+                .transpose(),
+        }
+    }
 }
 
 /// Custom response retrieved from endpoint, used for specializing responses

--- a/src/helix/moderation/manage_held_automod_messages.rs
+++ b/src/helix/moderation/manage_held_automod_messages.rs
@@ -147,6 +147,7 @@ impl RequestPost for ManageHeldAutoModMessagesRequest {
                 pagination: None,
                 request,
                 total: None,
+                other: None,
             }),
             _ => Err(helix::HelixRequestPostError::InvalidResponse {
                 reason: "unexpected status",

--- a/src/helix/points/create_custom_rewards.rs
+++ b/src/helix/points/create_custom_rewards.rs
@@ -164,6 +164,7 @@ impl RequestPost for CreateCustomRewardRequest {
             pagination: response.pagination.cursor,
             request,
             total: response.total,
+            other: None,
         })
     }
 }

--- a/src/helix/points/delete_custom_reward.rs
+++ b/src/helix/points/delete_custom_reward.rs
@@ -92,6 +92,7 @@ impl RequestDelete for DeleteCustomRewardRequest {
                 pagination: None,
                 request,
                 total: None,
+                other: None,
             }),
             _ => Err(helix::HelixRequestDeleteError::InvalidResponse {
                 reason: "unexpected status",

--- a/src/helix/points/update_custom_reward.rs
+++ b/src/helix/points/update_custom_reward.rs
@@ -195,6 +195,7 @@ impl RequestPatch for UpdateCustomRewardRequest {
             pagination: None,
             request,
             total: None,
+            other: None,
         })
     }
 }

--- a/src/helix/points/update_redemption_status.rs
+++ b/src/helix/points/update_redemption_status.rs
@@ -160,6 +160,7 @@ impl RequestPatch for UpdateRedemptionStatusRequest {
             pagination: None,
             request,
             total: None,
+            other: None,
         })
     }
 }

--- a/src/helix/polls/create_poll.rs
+++ b/src/helix/polls/create_poll.rs
@@ -174,6 +174,7 @@ impl RequestPost for CreatePollRequest {
             pagination: response.pagination.cursor,
             request,
             total: None,
+            other: None,
         })
     }
 }

--- a/src/helix/polls/end_poll.rs
+++ b/src/helix/polls/end_poll.rs
@@ -164,6 +164,7 @@ impl RequestPatch for EndPollRequest {
             pagination: None,
             request,
             total: None,
+            other: None,
         })
     }
 }

--- a/src/helix/predictions/create_prediction.rs
+++ b/src/helix/predictions/create_prediction.rs
@@ -166,6 +166,7 @@ impl RequestPost for CreatePredictionRequest {
             pagination: response.pagination.cursor,
             request,
             total: None,
+            other: None,
         })
     }
 }

--- a/src/helix/predictions/end_prediction.rs
+++ b/src/helix/predictions/end_prediction.rs
@@ -168,6 +168,7 @@ impl RequestPatch for EndPredictionRequest {
             pagination: None,
             request,
             total: None,
+            other: None,
         })
     }
 }

--- a/src/helix/schedule/update_channel_stream_schedule.rs
+++ b/src/helix/schedule/update_channel_stream_schedule.rs
@@ -115,6 +115,7 @@ impl RequestPatch for UpdateChannelStreamScheduleRequest {
             pagination: None,
             request,
             total: None,
+            other: None,
         })
     }
 }

--- a/src/helix/schedule/update_channel_stream_schedule_segment.rs
+++ b/src/helix/schedule/update_channel_stream_schedule_segment.rs
@@ -140,6 +140,7 @@ impl RequestPatch for UpdateChannelStreamScheduleSegmentRequest {
             pagination: response.pagination.cursor,
             request,
             total: response.total,
+            other: None,
         })
     }
 }

--- a/src/helix/search/search_categories.rs
+++ b/src/helix/search/search_categories.rs
@@ -97,6 +97,7 @@ impl RequestGet for SearchCategoriesRequest {
             pagination: response.pagination.cursor,
             request,
             total: response.total,
+            other: None,
         })
     }
 }

--- a/src/helix/streams/replace_stream_tags.rs
+++ b/src/helix/streams/replace_stream_tags.rs
@@ -124,6 +124,7 @@ impl RequestPut for ReplaceStreamTagsRequest {
                 pagination: None,
                 request,
                 total: None,
+                other: <_>::default(),
             }),
             _ => Err(helix::HelixRequestPutError::InvalidResponse {
                 reason: "unexpected status",

--- a/src/helix/subscriptions/check_user_subscription.rs
+++ b/src/helix/subscriptions/check_user_subscription.rs
@@ -115,6 +115,7 @@ impl RequestGet for CheckUserSubscriptionRequest {
             pagination: inner_response.pagination.cursor,
             request,
             total: inner_response.total,
+            other: inner_response.other,
         })
     }
 }

--- a/src/helix/users/block_user.rs
+++ b/src/helix/users/block_user.rs
@@ -125,6 +125,7 @@ impl RequestPut for BlockUserRequest {
                 pagination: None,
                 request,
                 total: None,
+                other: None,
             }),
             _ => Err(helix::HelixRequestPutError::InvalidResponse {
                 reason: "unexpected status",

--- a/src/helix/users/get_users_follows.rs
+++ b/src/helix/users/get_users_follows.rs
@@ -140,6 +140,7 @@ impl RequestGet for GetUsersFollowsRequest {
             pagination: response.pagination.cursor,
             request,
             total: Some(response.total),
+            other: None,
         })
     }
 }

--- a/src/helix/users/unblock_user.rs
+++ b/src/helix/users/unblock_user.rs
@@ -86,6 +86,7 @@ impl RequestDelete for UnblockUserRequest {
                 pagination: None,
                 request,
                 total: None,
+                other: None,
             }),
             _ => Err(helix::HelixRequestDeleteError::InvalidResponse {
                 reason: "unexpected status",

--- a/src/helix/videos/delete_videos.rs
+++ b/src/helix/videos/delete_videos.rs
@@ -86,6 +86,7 @@ impl RequestDelete for DeleteVideosRequest {
                 pagination: None,
                 request,
                 total: None,
+                other: None,
             }),
             _ => Err(helix::HelixRequestDeleteError::InvalidResponse {
                 reason: "unexpected status",


### PR DESCRIPTION
fixes getting points for broadcaster subscriptions


I'm not sure I like this approach. See for example https://github.com/Emilgardis/twitch_api2/blob/463d5bb915dd0f394c9131687d16eaf12e0f70da/src/helix/bits/get_bits_leaderboard.rs#L125-L159.

Broadcaster subscriptions used to have this, but was changed in #156 