### PR TITLE
chore: address new clippy lints

### DIFF
--- a/src/extra.rs
+++ b/src/extra.rs
@@ -20,6 +20,7 @@ pub struct DonationAmount {
 #[derive(PartialEq, Eq, serde_derive::Deserialize, serde_derive::Serialize, Debug, Clone)]
 #[serde(rename_all = "lowercase")]
 #[non_exhaustive]
+#[derive(Default)]
 pub enum AnnouncementColor {
     /// The color blue
     #[serde(alias = "BLUE")]
@@ -35,12 +36,8 @@ pub enum AnnouncementColor {
     Purple,
     /// The primary color for the broadcaster
     #[serde(alias = "PRIMARY")]
+    #[default]
     Primary,
-}
-
-#[cfg(any(feature = "eventsub", feature = "helix"))]
-impl Default for AnnouncementColor {
-    fn default() -> Self { Self::Primary }
 }
 
 /// An error for an invalid [AnnouncementColor]

--- a/src/helix/endpoints/users/get_user_active_extensions.rs
+++ b/src/helix/endpoints/users/get_user_active_extensions.rs
@@ -36,7 +36,6 @@ use std::collections::HashMap;
 
 use super::*;
 use helix::RequestGet;
-use serde::{Deserialize, Serialize};
 
 /// Query Parameters for [Get User Active Extensions](super::get_user_active_extensions)
 ///

--- a/src/helix/endpoints/users/get_users.rs
+++ b/src/helix/endpoints/users/get_users.rs
@@ -96,6 +96,11 @@ impl<'a> GetUsersRequest<'a> {
     }
 }
 
+impl<'a> Default for GetUsersRequest<'a> {
+    /// Returns an empty [`GetUsersRequest`]
+    fn default() -> Self { Self::new() }
+}
+
 /// Return Values for [Get Users](super::get_users)
 ///
 /// [`get-users`](https://dev.twitch.tv/docs/api/reference#get-users)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,6 @@
 #![allow(clippy::needless_raw_string_hashes)]
 #![cfg_attr(test, allow(deprecated))] // for pubsub tests
 #![cfg_attr(nightly, feature(doc_cfg))]
-#![allow(clippy::needless_raw_string_hashes)]
 #![doc(html_root_url = "https://docs.rs/twitch_api/0.7.2")]
 //! [![github]](https://github.com/twitch-rs/twitch_api)&ensp;[![crates-io]](https://crates.io/crates/twitch_api)&ensp;[![docs-rs-big]](https://docs.rs/twitch_api/0.7.2/twitch_api)
 //!


### PR DESCRIPTION
This addresses most clippy lints. Remaining are `result-large-err` warnings on the `parse_response`/`parse_inner_response` of `RequestPost` and friends:

> the `Err`-variant returned from this function is very large
try reducing the size of `helix::request::errors::HelixRequestDeleteError`, for example by boxing large elements or replacing it with `Box<helix::request::errors::HelixRequestDeleteError>`
for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#result_large_err

The error above is 176 bytes on x86_64. I'm not sure if it's worth to box these, because the `Ok`-variant of the response will be of a similar size. However, clippy doesn't know which types will be put into `Response<R, D>`.