### PR TITLE
refactor: Only include pagination data for paginated requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Removed surf dependency and related feature flags
 - Removed http-types dependency
+- The pagination state for helix requests was moved into a separate field (`pagination_data`). The type for this depends on the `Request`. Paginatable requests will use `PaginationState<Self>` while others will use `()`.
 
 [Commits](https://github.com/twitch-rs/twitch_api/compare/v0.7.2...Unreleased)
 

--- a/src/helix/client/client_ext.rs
+++ b/src/helix/client/client_ext.rs
@@ -782,7 +782,7 @@ impl<'client, C: crate::HttpClient + Sync + 'client> HelixClient<'client, C> {
             )
             .await?;
 
-        Ok(resp.total.unwrap_or(0))
+        Ok(resp.pagination_data.total.unwrap_or(0))
     }
 
     /// Get users followed channels

--- a/src/helix/endpoints/bits/get_bits_leaderboard.rs
+++ b/src/helix/endpoints/bits/get_bits_leaderboard.rs
@@ -176,6 +176,7 @@ pub struct LeaderboardUser {
 }
 
 impl Request for GetBitsLeaderboardRequest<'_> {
+    type PaginationData = ();
     type Response = BitsLeaderboard;
 
     const PATH: &'static str = "bits/leaderboard";
@@ -186,7 +187,7 @@ impl Request for GetBitsLeaderboardRequest<'_> {
 
 impl RequestGet for GetBitsLeaderboardRequest<'_> {
     fn parse_inner_response(
-        request: Option<Self>,
+        _request: Option<Self>,
         uri: &http::Uri,
         response: &str,
         status: http::StatusCode,
@@ -215,9 +216,7 @@ impl RequestGet for GetBitsLeaderboardRequest<'_> {
                 date_range: response.date_range,
                 total: response.total,
             },
-            None,
-            request,
-            Some(response.total),
+            (),
             None,
         ))
     }

--- a/src/helix/endpoints/bits/get_cheermotes.rs
+++ b/src/helix/endpoints/bits/get_cheermotes.rs
@@ -186,6 +186,7 @@ pub struct CheermoteImageArray {
 pub struct Level(pub String);
 
 impl Request for GetCheermotesRequest<'_> {
+    type PaginationData = ();
     type Response = Vec<Cheermote>;
 
     const PATH: &'static str = "bits/cheermotes";

--- a/src/helix/endpoints/ccls/get_content_classification_labels.rs
+++ b/src/helix/endpoints/ccls/get_content_classification_labels.rs
@@ -82,6 +82,7 @@ pub struct ContentClassificationLabel {
 }
 
 impl Request for GetContentClassificationLabelsRequest<'_> {
+    type PaginationData = ();
     type Response = Vec<ContentClassificationLabel>;
 
     const PATH: &'static str = "content_classification_labels";

--- a/src/helix/endpoints/channels/add_channel_vip.rs
+++ b/src/helix/endpoints/channels/add_channel_vip.rs
@@ -85,6 +85,7 @@ pub enum AddChannelVipResponse {
 }
 
 impl Request for AddChannelVipRequest<'_> {
+    type PaginationData = ();
     type Response = AddChannelVipResponse;
 
     const PATH: &'static str = "channels/vips";

--- a/src/helix/endpoints/channels/get_ad_schedule.rs
+++ b/src/helix/endpoints/channels/get_ad_schedule.rs
@@ -98,6 +98,7 @@ pub struct AdSchedule {
 }
 
 impl Request for GetAdScheduleRequest<'_> {
+    type PaginationData = ();
     type Response = Option<AdSchedule>;
 
     const PATH: &'static str = "channels/ads";
@@ -110,7 +111,7 @@ impl Request for GetAdScheduleRequest<'_> {
 
 impl RequestGet for GetAdScheduleRequest<'_> {
     fn parse_inner_response(
-        request: Option<Self>,
+        _request: Option<Self>,
         uri: &http::Uri,
         str_response: &str,
         status: http::StatusCode,
@@ -159,9 +160,7 @@ impl RequestGet for GetAdScheduleRequest<'_> {
         };
         Ok(helix::Response::new(
             response.data.into_iter().next(),
-            response.pagination.cursor,
-            request,
-            response.total,
+            (),
             response.other,
         ))
     }

--- a/src/helix/endpoints/channels/get_channel_editors.rs
+++ b/src/helix/endpoints/channels/get_channel_editors.rs
@@ -84,6 +84,7 @@ pub struct Editor {
 }
 
 impl Request for GetChannelEditorsRequest<'_> {
+    type PaginationData = ();
     type Response = Vec<Editor>;
 
     const PATH: &'static str = "channels/editors";

--- a/src/helix/endpoints/channels/get_channel_followers.rs
+++ b/src/helix/endpoints/channels/get_channel_followers.rs
@@ -38,6 +38,8 @@
 //!
 //! You can also get the [`http::Request`] with [`request.create_request(&token, &client_id)`](helix::RequestGet::create_request)
 //! and parse the [`http::Response`] with [`GetChannelFollowersRequest::parse_response(None, &request.get_uri(), response)`](GetChannelFollowersRequest::parse_response)
+use crate::helix::PaginationState;
+
 use super::*;
 use helix::RequestGet;
 
@@ -119,6 +121,7 @@ pub struct Follower {
 }
 
 impl Request for GetChannelFollowersRequest<'_> {
+    type PaginationData = PaginationState<Self>;
     type Response = Vec<Follower>;
 
     const PATH: &'static str = "channels/followers";

--- a/src/helix/endpoints/channels/get_channel_information.rs
+++ b/src/helix/endpoints/channels/get_channel_information.rs
@@ -119,6 +119,7 @@ pub struct ChannelInformation {
 }
 
 impl Request for GetChannelInformationRequest<'_> {
+    type PaginationData = ();
     type Response = Vec<ChannelInformation>;
 
     const PATH: &'static str = "channels";

--- a/src/helix/endpoints/channels/get_followed_channels.rs
+++ b/src/helix/endpoints/channels/get_followed_channels.rs
@@ -35,8 +35,9 @@
 //!
 //! You can also get the [`http::Request`] with [`request.create_request(&token, &client_id)`](helix::RequestGet::create_request)
 //! and parse the [`http::Response`] with [`GetFollowedChannels::parse_response(None, &request.get_uri(), response)`](GetFollowedChannels::parse_response)
+
 use super::*;
-use helix::RequestGet;
+use helix::{PaginationState, RequestGet};
 
 /// Query Parameters for [Get Followed Channels](super::get_followed_channels)
 ///
@@ -132,6 +133,7 @@ pub struct FollowedBroadcaster {
 }
 
 impl Request for GetFollowedChannels<'_> {
+    type PaginationData = PaginationState<Self>;
     type Response = Vec<FollowedBroadcaster>;
 
     const PATH: &'static str = "channels/followed";

--- a/src/helix/endpoints/channels/get_vips.rs
+++ b/src/helix/endpoints/channels/get_vips.rs
@@ -35,7 +35,7 @@
 //! You can also get the [`http::Request`] with [`request.create_request(&token, &client_id)`](helix::RequestGet::create_request)
 //! and parse the [`http::Response`] with [`GetVipsRequest::parse_response(None, &request.get_uri(), response)`](GetVipsRequest::parse_response)
 use super::*;
-use helix::RequestGet;
+use helix::{PaginationState, RequestGet};
 
 /// Query Parameters for [Get VIPs](super::get_vips)
 ///
@@ -129,6 +129,7 @@ pub struct Vip {
 }
 
 impl Request for GetVipsRequest<'_> {
+    type PaginationData = PaginationState<Self>;
     type Response = Vec<Vip>;
 
     const PATH: &'static str = "channels/vips";

--- a/src/helix/endpoints/channels/modify_channel_information.rs
+++ b/src/helix/endpoints/channels/modify_channel_information.rs
@@ -251,6 +251,7 @@ pub enum ModifyChannelInformation {
 }
 
 impl Request for ModifyChannelInformationRequest<'_> {
+    type PaginationData = ();
     type Response = ModifyChannelInformation;
 
     const PATH: &'static str = "channels";

--- a/src/helix/endpoints/channels/remove_channel_vip.rs
+++ b/src/helix/endpoints/channels/remove_channel_vip.rs
@@ -87,6 +87,7 @@ pub enum RemoveChannelVipResponse {
 }
 
 impl Request for RemoveChannelVipRequest<'_> {
+    type PaginationData = ();
     type Response = RemoveChannelVipResponse;
 
     const PATH: &'static str = "channels/vips";

--- a/src/helix/endpoints/channels/snooze_next_ad.rs
+++ b/src/helix/endpoints/channels/snooze_next_ad.rs
@@ -85,6 +85,7 @@ pub struct SnoozedAdSchedule {
 }
 
 impl Request for SnoozeNextAdRequest<'_> {
+    type PaginationData = ();
     type Response = SnoozedAdSchedule;
 
     const PATH: &'static str = "channels/ads/schedule/snooze";
@@ -97,7 +98,7 @@ impl RequestPost for SnoozeNextAdRequest<'_> {
     type Body = helix::EmptyBody;
 
     fn parse_inner_response(
-        request: Option<Self>,
+        _request: Option<Self>,
         uri: &http::Uri,
         response: &str,
         status: http::StatusCode,
@@ -124,9 +125,7 @@ impl RequestPost for SnoozeNextAdRequest<'_> {
                     status,
                     uri: uri.clone(),
                 })?,
-            resp.pagination.cursor,
-            request,
-            resp.total,
+            (),
             resp.other,
         ))
     }

--- a/src/helix/endpoints/channels/start_commercial.rs
+++ b/src/helix/endpoints/channels/start_commercial.rs
@@ -119,6 +119,7 @@ pub struct StartCommercial {
 }
 
 impl Request for StartCommercialRequest<'_> {
+    type PaginationData = ();
     /// FIXME: Make non-vec
     type Response = Vec<StartCommercial>;
 

--- a/src/helix/endpoints/charity/get_charity_campaign.rs
+++ b/src/helix/endpoints/charity/get_charity_campaign.rs
@@ -94,6 +94,7 @@ pub struct CharityCampaign {
 }
 
 impl Request for GetCharityCampaignRequest<'_> {
+    type PaginationData = ();
     type Response = Option<CharityCampaign>;
 
     const PATH: &'static str = "charity/campaigns";
@@ -104,7 +105,7 @@ impl Request for GetCharityCampaignRequest<'_> {
 
 impl RequestGet for GetCharityCampaignRequest<'_> {
     fn parse_inner_response(
-        request: Option<Self>,
+        _request: Option<Self>,
         uri: &http::Uri,
         response: &str,
         status: http::StatusCode,
@@ -123,9 +124,7 @@ impl RequestGet for GetCharityCampaignRequest<'_> {
             })?;
         Ok(helix::Response::new(
             response.data.into_iter().next(),
-            response.pagination.cursor,
-            request,
-            response.total,
+            (),
             response.other,
         ))
     }

--- a/src/helix/endpoints/charity/get_charity_campaign_donations.rs
+++ b/src/helix/endpoints/charity/get_charity_campaign_donations.rs
@@ -35,7 +35,7 @@
 //! You can also get the [`http::Request`] with [`request.create_request(&token, &client_id)`](helix::RequestGet::create_request)
 //! and parse the [`http::Response`] with [`GetCharityCampaignDonationsRequest::parse_response(None, &request.get_uri(), response)`](GetCharityCampaignDonationsRequest::parse_response)
 use super::*;
-use helix::RequestGet;
+use helix::{PaginationState, RequestGet};
 
 /// Query Parameters for [Get Charity Campaign Donations](super::get_charity_campaign_donations)
 ///
@@ -103,6 +103,7 @@ pub struct CharityCampaignDonation {
 }
 
 impl Request for GetCharityCampaignDonationsRequest<'_> {
+    type PaginationData = PaginationState<Self>;
     type Response = Vec<CharityCampaignDonation>;
 
     const PATH: &'static str = "charity/donations";

--- a/src/helix/endpoints/chat/get_channel_chat_badges.rs
+++ b/src/helix/endpoints/chat/get_channel_chat_badges.rs
@@ -69,6 +69,7 @@ impl<'a> GetChannelChatBadgesRequest<'a> {
 pub type GetChannelChatBadgesResponse = BadgeSet;
 
 impl Request for GetChannelChatBadgesRequest<'_> {
+    type PaginationData = ();
     type Response = Vec<GetChannelChatBadgesResponse>;
 
     const PATH: &'static str = "chat/badges";

--- a/src/helix/endpoints/chat/get_channel_emotes.rs
+++ b/src/helix/endpoints/chat/get_channel_emotes.rs
@@ -67,6 +67,7 @@ impl<'a> GetChannelEmotesRequest<'a> {
 pub type GetChannelEmotesResponse = ChannelEmote;
 
 impl Request for GetChannelEmotesRequest<'_> {
+    type PaginationData = ();
     type Response = Vec<GetChannelEmotesResponse>;
 
     const PATH: &'static str = "chat/emotes";

--- a/src/helix/endpoints/chat/get_chat_settings.rs
+++ b/src/helix/endpoints/chat/get_chat_settings.rs
@@ -103,6 +103,7 @@ impl<'a> GetChatSettingsRequest<'a> {
 }
 
 impl Request for GetChatSettingsRequest<'_> {
+    type PaginationData = ();
     type Response = ChatSettings;
 
     #[cfg(feature = "twitch_oauth2")]

--- a/src/helix/endpoints/chat/get_chatters.rs
+++ b/src/helix/endpoints/chat/get_chatters.rs
@@ -38,7 +38,7 @@
 //! and parse the [`http::Response`] with [`GetChattersRequest::parse_response(None, &request.get_uri(), response)`](GetChattersRequest::parse_response)
 
 use super::*;
-use helix::RequestGet;
+use helix::{PaginationState, RequestGet};
 
 /// Query Parameters for [Get Chatters](super::get_chatters)
 ///
@@ -114,6 +114,7 @@ pub struct Chatter {
 }
 
 impl Request for GetChattersRequest<'_> {
+    type PaginationData = PaginationState<Self>;
     type Response = Vec<Chatter>;
 
     const PATH: &'static str = "chat/chatters";

--- a/src/helix/endpoints/chat/get_emote_sets.rs
+++ b/src/helix/endpoints/chat/get_emote_sets.rs
@@ -117,6 +117,7 @@ impl Emote {
 }
 
 impl Request for GetEmoteSetsRequest<'_> {
+    type PaginationData = ();
     type Response = Vec<Emote>;
 
     const PATH: &'static str = "chat/emotes/set";

--- a/src/helix/endpoints/chat/get_global_chat_badges.rs
+++ b/src/helix/endpoints/chat/get_global_chat_badges.rs
@@ -56,6 +56,7 @@ impl GetGlobalChatBadgesRequest {
 pub type GetGlobalChatBadgesResponse = BadgeSet;
 
 impl Request for GetGlobalChatBadgesRequest {
+    type PaginationData = ();
     type Response = Vec<GetGlobalChatBadgesResponse>;
 
     const PATH: &'static str = "chat/badges/global";

--- a/src/helix/endpoints/chat/get_global_emotes.rs
+++ b/src/helix/endpoints/chat/get_global_emotes.rs
@@ -56,6 +56,7 @@ impl GetGlobalEmotesRequest {
 pub type GetChannelEmotesResponse = GlobalEmote;
 
 impl Request for GetGlobalEmotesRequest {
+    type PaginationData = ();
     type Response = Vec<GetChannelEmotesResponse>;
 
     const PATH: &'static str = "chat/emotes/global";

--- a/src/helix/endpoints/chat/get_shared_chat_session.rs
+++ b/src/helix/endpoints/chat/get_shared_chat_session.rs
@@ -90,6 +90,7 @@ pub struct SharedChatParticipant {
 }
 
 impl Request for GetSharedChatSessionRequest<'_> {
+    type PaginationData = ();
     type Response = Option<SharedChatSession>;
 
     const PATH: &'static str = "shared_chat/session";

--- a/src/helix/endpoints/chat/get_user_chat_color.rs
+++ b/src/helix/endpoints/chat/get_user_chat_color.rs
@@ -99,6 +99,7 @@ pub struct UserChatColor {
 }
 
 impl Request for GetUserChatColorRequest<'_> {
+    type PaginationData = ();
     type Response = Vec<UserChatColor>;
 
     const PATH: &'static str = "chat/color";

--- a/src/helix/endpoints/chat/get_user_emotes.rs
+++ b/src/helix/endpoints/chat/get_user_emotes.rs
@@ -34,7 +34,7 @@
 //! and parse the [`http::Response`] with [`GetUserEmotesRequest::parse_response(None, &request.get_uri(), response)`](GetUserEmotesRequest::parse_response)
 
 use super::*;
-use helix::RequestGet;
+use helix::{PaginationState, RequestGet};
 
 /// Query Parameters for [Get User Emotes](super::get_user_emotes)
 ///
@@ -125,6 +125,7 @@ impl UserEmote {
 }
 
 impl Request for GetUserEmotesRequest<'_> {
+    type PaginationData = PaginationState<Self>;
     type Response = Vec<UserEmote>;
 
     const PATH: &'static str = "chat/emotes/user";

--- a/src/helix/endpoints/chat/send_a_shoutout.rs
+++ b/src/helix/endpoints/chat/send_a_shoutout.rs
@@ -85,6 +85,7 @@ pub enum SendAShoutoutResponse {
     Success,
 }
 impl Request for SendAShoutoutRequest<'_> {
+    type PaginationData = ();
     type Response = SendAShoutoutResponse;
 
     const PATH: &'static str = "chat/shoutouts";

--- a/src/helix/endpoints/chat/send_chat_announcement.rs
+++ b/src/helix/endpoints/chat/send_chat_announcement.rs
@@ -152,6 +152,7 @@ pub enum SendChatAnnouncementResponse {
 }
 
 impl Request for SendChatAnnouncementRequest<'_> {
+    type PaginationData = ();
     // FIXME: this is a single entry
     type Response = SendChatAnnouncementResponse;
 

--- a/src/helix/endpoints/chat/send_chat_message.rs
+++ b/src/helix/endpoints/chat/send_chat_message.rs
@@ -268,6 +268,7 @@ pub struct SendChatMessageResponse {
 }
 
 impl Request for SendChatMessageRequest<'_> {
+    type PaginationData = ();
     type Response = SendChatMessageResponse;
 
     const PATH: &'static str = "chat/messages";

--- a/src/helix/endpoints/chat/update_chat_settings.rs
+++ b/src/helix/endpoints/chat/update_chat_settings.rs
@@ -172,6 +172,7 @@ impl helix::private::SealedSerialize for UpdateChatSettingsBody {}
 pub type UpdateChatSettingsResponse = ChatSettings;
 
 impl Request for UpdateChatSettingsRequest<'_> {
+    type PaginationData = ();
     type Response = ChatSettings;
 
     const PATH: &'static str = "chat/settings";

--- a/src/helix/endpoints/chat/update_user_chat_color.rs
+++ b/src/helix/endpoints/chat/update_user_chat_color.rs
@@ -87,6 +87,7 @@ pub enum UpdateUserChatColorResponse {
 }
 
 impl Request for UpdateUserChatColorRequest<'_> {
+    type PaginationData = ();
     type Response = UpdateUserChatColorResponse;
 
     const PATH: &'static str = "chat/color";

--- a/src/helix/endpoints/clips/create_clip.rs
+++ b/src/helix/endpoints/clips/create_clip.rs
@@ -86,6 +86,7 @@ pub struct CreatedClip {
 }
 
 impl Request for CreateClipRequest<'_> {
+    type PaginationData = ();
     type Response = CreatedClip;
 
     const PATH: &'static str = "clips";

--- a/src/helix/endpoints/clips/get_clips.rs
+++ b/src/helix/endpoints/clips/get_clips.rs
@@ -34,7 +34,7 @@
 //! and parse the [`http::Response`] with [`GetClipsRequest::parse_response(None, &request.get_uri(), response)`](GetClipsRequest::parse_response)
 
 use super::*;
-use helix::RequestGet;
+use helix::{PaginationState, RequestGet};
 
 /// Query Parameters for [Get Clips](super::get_clips)
 ///
@@ -199,6 +199,7 @@ pub struct Clip {
 }
 
 impl Request for GetClipsRequest<'_> {
+    type PaginationData = PaginationState<Self>;
     type Response = Vec<Clip>;
 
     const PATH: &'static str = "clips";

--- a/src/helix/endpoints/eventsub/create_conduit.rs
+++ b/src/helix/endpoints/eventsub/create_conduit.rs
@@ -15,6 +15,7 @@ use helix::RequestPost;
 pub struct CreateConduitRequest {}
 
 impl Request for CreateConduitRequest {
+    type PaginationData = ();
     type Response = eventsub::Conduit;
 
     const PATH: &'static str = "eventsub/conduits";
@@ -44,7 +45,7 @@ impl RequestPost for CreateConduitRequest {
     type Body = CreateConduitBody;
 
     fn parse_inner_response(
-        request: Option<Self>,
+        _request: Option<Self>,
         uri: &http::Uri,
         response: &str,
         status: http::StatusCode,
@@ -69,7 +70,7 @@ impl RequestPost for CreateConduitRequest {
 
         let [conduit] = inner_response.data;
 
-        Ok(helix::Response::new(conduit, None, request, None, None))
+        Ok(helix::Response::new(conduit, (), None))
     }
 }
 

--- a/src/helix/endpoints/eventsub/create_eventsub_subscription.rs
+++ b/src/helix/endpoints/eventsub/create_eventsub_subscription.rs
@@ -31,6 +31,7 @@ impl<E: EventSubscription> Default for CreateEventSubSubscriptionRequest<E> {
 }
 
 impl<E: EventSubscription> helix::Request for CreateEventSubSubscriptionRequest<E> {
+    type PaginationData = ();
     type Response = CreateEventSubSubscription<E>;
 
     #[cfg(feature = "twitch_oauth2")]

--- a/src/helix/endpoints/eventsub/delete_conduit.rs
+++ b/src/helix/endpoints/eventsub/delete_conduit.rs
@@ -38,6 +38,7 @@ pub enum DeleteConduitResponse {
 }
 
 impl Request for DeleteConduitRequest<'_> {
+    type PaginationData = ();
     type Response = DeleteConduitResponse;
 
     const PATH: &'static str = "eventsub/conduits";

--- a/src/helix/endpoints/eventsub/delete_eventsub_subscription.rs
+++ b/src/helix/endpoints/eventsub/delete_eventsub_subscription.rs
@@ -25,6 +25,7 @@ impl<'a> DeleteEventSubSubscriptionRequest<'a> {
 }
 
 impl Request for DeleteEventSubSubscriptionRequest<'_> {
+    type PaginationData = ();
     type Response = DeleteEventSubSubscription;
 
     const PATH: &'static str = "eventsub/subscriptions";

--- a/src/helix/endpoints/eventsub/get_conduit_shards.rs
+++ b/src/helix/endpoints/eventsub/get_conduit_shards.rs
@@ -3,7 +3,7 @@
 
 use super::*;
 use crate::eventsub;
-use helix::RequestGet;
+use helix::{PaginationState, RequestGet};
 
 /// Query Parameters for [Get Conduit Shards](super::get_conduit_shards)
 ///
@@ -63,6 +63,7 @@ pub struct ConduitShards {
 }
 
 impl Request for GetConduitShardsRequest<'_> {
+    type PaginationData = PaginationState<Self>;
     type Response = Vec<eventsub::ShardResponse>;
 
     const PATH: &'static str = "eventsub/conduits/shards";

--- a/src/helix/endpoints/eventsub/get_conduits.rs
+++ b/src/helix/endpoints/eventsub/get_conduits.rs
@@ -15,6 +15,7 @@ use helix::RequestGet;
 pub struct GetConduitsRequest {}
 
 impl Request for GetConduitsRequest {
+    type PaginationData = ();
     type Response = Vec<eventsub::Conduit>;
 
     const PATH: &'static str = "eventsub/conduits";

--- a/src/helix/endpoints/eventsub/get_eventsub_subscriptions.rs
+++ b/src/helix/endpoints/eventsub/get_eventsub_subscriptions.rs
@@ -2,7 +2,7 @@
 
 use super::*;
 use crate::eventsub;
-use helix::RequestGet;
+use helix::{pagination::PaginationData, PaginationState, RequestGet};
 
 /// Query Parameters for [Get EventSub Subscriptions](super::get_eventsub_subscriptions)
 ///
@@ -55,6 +55,7 @@ impl GetEventSubSubscriptionsRequest<'_> {
 }
 
 impl Request for GetEventSubSubscriptionsRequest<'_> {
+    type PaginationData = PaginationState<Self>;
     type Response = EventSubSubscriptions;
 
     const PATH: &'static str = "eventsub/subscriptions";
@@ -117,9 +118,7 @@ impl RequestGet for GetEventSubSubscriptionsRequest<'_> {
                 max_total_cost: response.max_total_cost,
                 subscriptions: response.data,
             },
-            response.pagination.cursor,
-            request,
-            Some(response.total),
+            PaginationState::new(response.pagination.cursor, request, Some(response.total)),
             None,
         ))
     }

--- a/src/helix/endpoints/eventsub/update_conduit.rs
+++ b/src/helix/endpoints/eventsub/update_conduit.rs
@@ -22,6 +22,7 @@ pub struct UpdateConduitRequest<'a> {
 }
 
 impl Request for UpdateConduitRequest<'_> {
+    type PaginationData = ();
     type Response = eventsub::Conduit;
 
     const PATH: &'static str = "eventsub/conduits";

--- a/src/helix/endpoints/eventsub/update_conduit_shards.rs
+++ b/src/helix/endpoints/eventsub/update_conduit_shards.rs
@@ -19,6 +19,7 @@ pub struct UpdateConduitShardsRequest<'a> {
 }
 
 impl Request for UpdateConduitShardsRequest<'_> {
+    type PaginationData = ();
     type Response = UpdateConduitShardsResponse;
 
     const PATH: &'static str = "eventsub/conduits/shards";
@@ -75,7 +76,7 @@ impl<'a> RequestPatch for UpdateConduitShardsRequest<'a> {
     type Body = UpdateConduitShardsBody<'a>;
 
     fn parse_inner_response(
-        request: Option<Self>,
+        _request: Option<Self>,
         uri: &http::Uri,
         response: &str,
         status: http::StatusCode,
@@ -104,9 +105,7 @@ impl<'a> RequestPatch for UpdateConduitShardsRequest<'a> {
                 shards: inner_response.data,
                 errors: inner_response.errors,
             },
-            None,
-            request,
-            None,
+            (),
             None,
         ))
     }

--- a/src/helix/endpoints/games/get_games.rs
+++ b/src/helix/endpoints/games/get_games.rs
@@ -94,6 +94,7 @@ impl<'a> GetGamesRequest<'a> {
 pub type Game = types::TwitchCategory;
 
 impl Request for GetGamesRequest<'_> {
+    type PaginationData = ();
     type Response = Vec<Game>;
 
     const PATH: &'static str = "games";

--- a/src/helix/endpoints/games/get_top_games.rs
+++ b/src/helix/endpoints/games/get_top_games.rs
@@ -34,7 +34,7 @@
 //! and parse the [`http::Response`] with [`GetTopGamesRequest::parse_response(None, &request.get_uri(), response)`](GetTopGamesRequest::parse_response)
 
 use super::*;
-use helix::RequestGet;
+use helix::{PaginationState, RequestGet};
 
 /// Query Parameters for [Get Top Games](super::get_games)
 ///
@@ -71,6 +71,7 @@ impl GetTopGamesRequest<'_> {
 pub type Game = types::TwitchCategory;
 
 impl Request for GetTopGamesRequest<'_> {
+    type PaginationData = PaginationState<Self>;
     type Response = Vec<Game>;
 
     const PATH: &'static str = "games/top";

--- a/src/helix/endpoints/goals/get_creator_goals.rs
+++ b/src/helix/endpoints/goals/get_creator_goals.rs
@@ -108,6 +108,7 @@ pub struct CreatorGoal {
 }
 
 impl Request for GetCreatorGoalsRequest<'_> {
+    type PaginationData = ();
     type Response = Vec<CreatorGoal>;
 
     const PATH: &'static str = "goals";

--- a/src/helix/endpoints/hypetrain/get_hypetrain_events.rs
+++ b/src/helix/endpoints/hypetrain/get_hypetrain_events.rs
@@ -36,7 +36,7 @@
 //! and parse the [`http::Response`] with [`GetHypeTrainEventsRequest::parse_response(None, &request.get_uri(), response)`](GetHypeTrainEventsRequest::parse_response)
 
 use super::*;
-use helix::RequestGet;
+use helix::{PaginationState, RequestGet};
 
 /// Query Parameters for [Get Hype Train Events](super::get_hypetrain_events)
 ///
@@ -135,6 +135,7 @@ pub struct HypeTrainEventData {
 }
 
 impl Request for GetHypeTrainEventsRequest<'_> {
+    type PaginationData = PaginationState<Self>;
     type Response = Vec<HypeTrainEvent>;
 
     const PATH: &'static str = "hypetrain/events";

--- a/src/helix/endpoints/moderation/add_blocked_term.rs
+++ b/src/helix/endpoints/moderation/add_blocked_term.rs
@@ -123,6 +123,7 @@ impl helix::HelixRequestBody for [AddBlockedTermBody<'_>] {
 pub type AddBlockedTermResponse = BlockedTerm;
 
 impl Request for AddBlockedTermRequest<'_> {
+    type PaginationData = ();
     // FIXME: this is a single entry
     type Response = Vec<BlockedTerm>;
 

--- a/src/helix/endpoints/moderation/add_channel_moderator.rs
+++ b/src/helix/endpoints/moderation/add_channel_moderator.rs
@@ -82,6 +82,7 @@ pub enum AddChannelModeratorResponse {
 }
 
 impl Request for AddChannelModeratorRequest<'_> {
+    type PaginationData = ();
     type Response = AddChannelModeratorResponse;
 
     const PATH: &'static str = "moderation/moderators";

--- a/src/helix/endpoints/moderation/ban_user.rs
+++ b/src/helix/endpoints/moderation/ban_user.rs
@@ -156,6 +156,7 @@ pub struct BanUser {
 }
 
 impl Request for BanUserRequest<'_> {
+    type PaginationData = ();
     type Response = BanUser;
 
     const PATH: &'static str = "moderation/bans";

--- a/src/helix/endpoints/moderation/check_automod_status.rs
+++ b/src/helix/endpoints/moderation/check_automod_status.rs
@@ -144,6 +144,7 @@ pub struct CheckAutoModStatus {
 }
 
 impl Request for CheckAutoModStatusRequest<'_> {
+    type PaginationData = ();
     type Response = Vec<CheckAutoModStatus>;
 
     const PATH: &'static str = "moderation/enforcements/status";

--- a/src/helix/endpoints/moderation/delete_chat_messages.rs
+++ b/src/helix/endpoints/moderation/delete_chat_messages.rs
@@ -103,6 +103,7 @@ pub enum DeleteChatMessagesResponse {
 }
 
 impl Request for DeleteChatMessagesRequest<'_> {
+    type PaginationData = ();
     type Response = DeleteChatMessagesResponse;
 
     #[cfg(feature = "twitch_oauth2")]

--- a/src/helix/endpoints/moderation/get_automod_settings.rs
+++ b/src/helix/endpoints/moderation/get_automod_settings.rs
@@ -100,6 +100,7 @@ pub struct AutoModSettings {
 }
 
 impl Request for GetAutoModSettingsRequest<'_> {
+    type PaginationData = ();
     type Response = AutoModSettings;
 
     const PATH: &'static str = "moderation/automod/settings";

--- a/src/helix/endpoints/moderation/get_banned_users.rs
+++ b/src/helix/endpoints/moderation/get_banned_users.rs
@@ -35,7 +35,7 @@
 //! and parse the [`http::Response`] with [`GetBannedUsersRequest::parse_response(None, &request.get_uri(), response)`](GetBannedUsersRequest::parse_response)
 
 use super::*;
-use helix::RequestGet;
+use helix::{PaginationState, RequestGet};
 
 /// Query Parameters for [Get Banned Users](super::get_banned_users)
 ///
@@ -123,6 +123,7 @@ pub struct BannedUser {
 }
 
 impl Request for GetBannedUsersRequest<'_> {
+    type PaginationData = PaginationState<Self>;
     type Response = Vec<BannedUser>;
 
     const PATH: &'static str = "moderation/banned";

--- a/src/helix/endpoints/moderation/get_blocked_terms.rs
+++ b/src/helix/endpoints/moderation/get_blocked_terms.rs
@@ -36,7 +36,7 @@
 //! and parse the [`http::Response`] with [`GetBlockedTermsRequest::parse_response(None, &request.get_uri(), response)`](GetBlockedTermsRequest::parse_response)
 
 use super::*;
-use helix::RequestGet;
+use helix::{PaginationState, RequestGet};
 
 /// Query Parameters for [Get Blocked Terms](super::get_blocked_terms)
 ///
@@ -91,6 +91,7 @@ impl<'a> GetBlockedTermsRequest<'a> {
 pub type GetBlockedTermsResponse = BlockedTerm;
 
 impl Request for GetBlockedTermsRequest<'_> {
+    type PaginationData = PaginationState<Self>;
     type Response = Vec<BlockedTerm>;
 
     const PATH: &'static str = "moderation/blocked_terms";

--- a/src/helix/endpoints/moderation/get_moderated_channels.rs
+++ b/src/helix/endpoints/moderation/get_moderated_channels.rs
@@ -34,7 +34,7 @@
 //! You can also get the [`http::Request`] with [`request.create_request(&token, &client_id)`](helix::RequestGet::create_request)
 //! and parse the [`http::Response`] with [`GetModeratedChannelsRequest::parse_response(None, &request.get_uri(), response)`](GetModeratedChannelsRequest::parse_response)
 use super::*;
-use helix::RequestGet;
+use helix::{PaginationState, RequestGet};
 
 /// Query Parameters for [Get Moderated Channels](super::get_moderated_channels)
 ///
@@ -90,6 +90,7 @@ pub struct ModeratedChannel {
 }
 
 impl Request for GetModeratedChannelsRequest<'_> {
+    type PaginationData = PaginationState<Self>;
     type Response = Vec<ModeratedChannel>;
 
     const PATH: &'static str = "moderation/channels";

--- a/src/helix/endpoints/moderation/get_moderators.rs
+++ b/src/helix/endpoints/moderation/get_moderators.rs
@@ -33,7 +33,7 @@
 //! You can also get the [`http::Request`] with [`request.create_request(&token, &client_id)`](helix::RequestGet::create_request)
 //! and parse the [`http::Response`] with [`GetModeratorsRequest::parse_response(None, &request.get_uri(), response)`](GetModeratorsRequest::parse_response)
 use super::*;
-use helix::RequestGet;
+use helix::{PaginationState, RequestGet};
 
 // Format: Repeated Query Parameter, eg. /moderation/banned?broadcaster_id=1&user_id=2&user_id=3
 // Maximum: 100
@@ -104,6 +104,7 @@ pub struct Moderator {
 }
 
 impl Request for GetModeratorsRequest<'_> {
+    type PaginationData = PaginationState<Self>;
     type Response = Vec<Moderator>;
 
     const PATH: &'static str = "moderation/moderators";

--- a/src/helix/endpoints/moderation/get_shield_mode_status.rs
+++ b/src/helix/endpoints/moderation/get_shield_mode_status.rs
@@ -143,6 +143,7 @@ pub struct LastShieldMode {
 
 impl LastShieldMode {}
 impl Request for GetShieldModeStatusRequest<'_> {
+    type PaginationData = ();
     type Response = ShieldModeStatus;
 
     const PATH: &'static str = "moderation/shield_mode";
@@ -155,7 +156,7 @@ impl Request for GetShieldModeStatusRequest<'_> {
 
 impl RequestGet for GetShieldModeStatusRequest<'_> {
     fn parse_inner_response(
-        request: Option<Self>,
+        _request: Option<Self>,
         uri: &http::Uri,
         response: &str,
         status: http::StatusCode,
@@ -181,9 +182,7 @@ impl RequestGet for GetShieldModeStatusRequest<'_> {
                     uri: uri.clone(),
                 },
             )?,
-            inner_response.pagination.cursor,
-            request,
-            inner_response.total,
+            (),
             inner_response.other,
         ))
     }

--- a/src/helix/endpoints/moderation/get_unban_requests.rs
+++ b/src/helix/endpoints/moderation/get_unban_requests.rs
@@ -39,7 +39,7 @@
 //! and parse the [`http::Response`] with [`GetUnbanRequestsRequest::parse_response(None, &request.get_uri(), response)`](GetUnbanRequestsRequest::parse_response)
 
 use super::*;
-use helix::RequestGet;
+use helix::{PaginationState, RequestGet};
 
 /// The status of an unban request
 #[derive(PartialEq, Eq, Debug, Clone, Serialize, Deserialize)]
@@ -159,6 +159,7 @@ pub struct UnbanRequest {
 }
 
 impl Request for GetUnbanRequestsRequest<'_> {
+    type PaginationData = PaginationState<Self>;
     type Response = Vec<UnbanRequest>;
 
     const PATH: &'static str = "moderation/unban_requests";

--- a/src/helix/endpoints/moderation/manage_held_automod_messages.rs
+++ b/src/helix/endpoints/moderation/manage_held_automod_messages.rs
@@ -152,6 +152,7 @@ pub enum ManageHeldAutoModMessages {
 }
 
 impl Request for ManageHeldAutoModMessagesRequest<'_> {
+    type PaginationData = ();
     type Response = ManageHeldAutoModMessages;
 
     const PATH: &'static str = "moderation/automod/message";

--- a/src/helix/endpoints/moderation/remove_blocked_term.rs
+++ b/src/helix/endpoints/moderation/remove_blocked_term.rs
@@ -86,6 +86,7 @@ pub enum RemoveBlockedTerm {
 }
 
 impl Request for RemoveBlockedTermRequest<'_> {
+    type PaginationData = ();
     type Response = RemoveBlockedTerm;
 
     #[cfg(feature = "twitch_oauth2")]

--- a/src/helix/endpoints/moderation/remove_channel_moderator.rs
+++ b/src/helix/endpoints/moderation/remove_channel_moderator.rs
@@ -83,6 +83,7 @@ pub enum RemoveChannelModeratorResponse {
 }
 
 impl Request for RemoveChannelModeratorRequest<'_> {
+    type PaginationData = ();
     type Response = RemoveChannelModeratorResponse;
 
     const PATH: &'static str = "moderation/moderators";

--- a/src/helix/endpoints/moderation/resolve_unban_request.rs
+++ b/src/helix/endpoints/moderation/resolve_unban_request.rs
@@ -138,6 +138,7 @@ impl<'a> ResolveUnbanRequest<'a> {
 }
 
 impl Request for ResolveUnbanRequest<'_> {
+    type PaginationData = ();
     type Response = super::UnbanRequest;
 
     const PATH: &'static str = "moderation/unban_requests";

--- a/src/helix/endpoints/moderation/unban_user.rs
+++ b/src/helix/endpoints/moderation/unban_user.rs
@@ -86,6 +86,7 @@ pub enum UnbanUserResponse {
 }
 
 impl Request for UnbanUserRequest<'_> {
+    type PaginationData = ();
     type Response = UnbanUserResponse;
 
     const PATH: &'static str = "moderation/bans";

--- a/src/helix/endpoints/moderation/update_automod_settings.rs
+++ b/src/helix/endpoints/moderation/update_automod_settings.rs
@@ -187,6 +187,7 @@ impl UpdateAutoModSettingsIndividual {
 }
 
 impl Request for UpdateAutoModSettingsRequest<'_> {
+    type PaginationData = ();
     type Response = super::AutoModSettings;
 
     const PATH: &'static str = "moderation/automod/settings";

--- a/src/helix/endpoints/moderation/update_shield_mode_status.rs
+++ b/src/helix/endpoints/moderation/update_shield_mode_status.rs
@@ -115,6 +115,7 @@ impl UpdateShieldModeStatusBody<'_> {
 }
 
 impl Request for UpdateShieldModeStatusRequest<'_> {
+    type PaginationData = ();
     type Response = super::ShieldModeStatus;
 
     const PATH: &'static str = "moderation/shield_mode";
@@ -127,7 +128,7 @@ impl<'a> RequestPut for UpdateShieldModeStatusRequest<'a> {
     type Body = UpdateShieldModeStatusBody<'a>;
 
     fn parse_inner_response(
-        request: Option<Self>,
+        _request: Option<Self>,
         uri: &http::Uri,
         response: &str,
         status: http::StatusCode,
@@ -153,9 +154,7 @@ impl<'a> RequestPut for UpdateShieldModeStatusRequest<'a> {
                     uri: uri.clone(),
                 },
             )?,
-            inner_response.pagination.cursor,
-            request,
-            inner_response.total,
+            (),
             inner_response.other,
         ))
     }

--- a/src/helix/endpoints/moderation/warn_chat_user.rs
+++ b/src/helix/endpoints/moderation/warn_chat_user.rs
@@ -147,6 +147,7 @@ pub struct WarnChatUser {
 }
 
 impl Request for WarnChatUserRequest<'_> {
+    type PaginationData = ();
     type Response = WarnChatUser;
 
     const PATH: &'static str = "moderation/warnings";

--- a/src/helix/endpoints/points/create_custom_rewards.rs
+++ b/src/helix/endpoints/points/create_custom_rewards.rs
@@ -165,6 +165,7 @@ impl helix::private::SealedSerialize for CreateCustomRewardBody<'_> {}
 pub type CreateCustomRewardResponse = super::CustomReward;
 
 impl Request for CreateCustomRewardRequest<'_> {
+    type PaginationData = ();
     type Response = CreateCustomRewardResponse;
 
     const PATH: &'static str = "channel_points/custom_rewards";
@@ -177,7 +178,7 @@ impl<'a> RequestPost for CreateCustomRewardRequest<'a> {
     type Body = CreateCustomRewardBody<'a>;
 
     fn parse_inner_response(
-        request: Option<Self>,
+        _request: Option<Self>,
         uri: &http::Uri,
         response_str: &str,
         status: http::StatusCode,
@@ -204,9 +205,7 @@ impl<'a> RequestPost for CreateCustomRewardRequest<'a> {
         })?;
         Ok(helix::Response {
             data,
-            pagination: response.pagination.cursor,
-            request,
-            total: response.total,
+            pagination_data: (),
             other: None,
         })
     }

--- a/src/helix/endpoints/points/delete_custom_reward.rs
+++ b/src/helix/endpoints/points/delete_custom_reward.rs
@@ -83,6 +83,7 @@ pub enum DeleteCustomReward {
 }
 
 impl Request for DeleteCustomRewardRequest<'_> {
+    type PaginationData = ();
     type Response = DeleteCustomReward;
 
     const PATH: &'static str = "channel_points/custom_rewards";

--- a/src/helix/endpoints/points/get_custom_reward.rs
+++ b/src/helix/endpoints/points/get_custom_reward.rs
@@ -135,6 +135,7 @@ pub struct CustomReward {
 }
 
 impl Request for GetCustomRewardRequest<'_> {
+    type PaginationData = ();
     type Response = Vec<CustomReward>;
 
     const PATH: &'static str = "channel_points/custom_rewards";

--- a/src/helix/endpoints/points/get_custom_reward_redemption.rs
+++ b/src/helix/endpoints/points/get_custom_reward_redemption.rs
@@ -43,7 +43,7 @@
 //! and parse the [`http::Response`] with [`GetCustomRewardRedemptionRequest::parse_response(None, &request.get_uri(), response)`](GetCustomRewardRedemptionRequest::parse_response)
 
 use super::*;
-use helix::RequestGet;
+use helix::{PaginationState, RequestGet};
 
 /// Query Parameters for [Get Custom Reward Redemption](super::get_custom_reward_redemption)
 ///
@@ -201,6 +201,7 @@ pub struct Reward {
 }
 
 impl Request for GetCustomRewardRedemptionRequest<'_> {
+    type PaginationData = PaginationState<Self>;
     type Response = Vec<CustomRewardRedemption>;
 
     const PATH: &'static str = "channel_points/custom_rewards/redemptions";

--- a/src/helix/endpoints/points/update_custom_reward.rs
+++ b/src/helix/endpoints/points/update_custom_reward.rs
@@ -171,6 +171,7 @@ pub enum UpdateCustomReward {
 }
 
 impl Request for UpdateCustomRewardRequest<'_> {
+    type PaginationData = ();
     type Response = UpdateCustomReward;
 
     const PATH: &'static str = "channel_points/custom_rewards";

--- a/src/helix/endpoints/points/update_redemption_status.rs
+++ b/src/helix/endpoints/points/update_redemption_status.rs
@@ -137,6 +137,7 @@ pub enum UpdateRedemptionStatusInformation {
 }
 
 impl Request for UpdateRedemptionStatusRequest<'_> {
+    type PaginationData = ();
     type Response = UpdateRedemptionStatusInformation;
 
     const PATH: &'static str = "channel_points/custom_rewards/redemptions";

--- a/src/helix/endpoints/polls/create_poll.rs
+++ b/src/helix/endpoints/polls/create_poll.rs
@@ -174,6 +174,7 @@ impl<'a> NewPollChoice<'a> {
 pub type CreatePollResponse = super::Poll;
 
 impl Request for CreatePollRequest<'_> {
+    type PaginationData = ();
     type Response = CreatePollResponse;
 
     const PATH: &'static str = "polls";
@@ -186,7 +187,7 @@ impl<'a> RequestPost for CreatePollRequest<'a> {
     type Body = CreatePollBody<'a>;
 
     fn parse_inner_response(
-        request: Option<Self>,
+        _request: Option<Self>,
         uri: &http::Uri,
         response_str: &str,
         status: http::StatusCode,
@@ -213,9 +214,7 @@ impl<'a> RequestPost for CreatePollRequest<'a> {
         })?;
         Ok(helix::Response {
             data,
-            pagination: response.pagination.cursor,
-            request,
-            total: None,
+            pagination_data: (),
             other: None,
         })
     }

--- a/src/helix/endpoints/polls/end_poll.rs
+++ b/src/helix/endpoints/polls/end_poll.rs
@@ -135,6 +135,7 @@ pub enum EndPoll {
 }
 
 impl Request for EndPollRequest<'_> {
+    type PaginationData = ();
     type Response = EndPoll;
 
     const PATH: &'static str = "polls";

--- a/src/helix/endpoints/polls/get_polls.rs
+++ b/src/helix/endpoints/polls/get_polls.rs
@@ -34,7 +34,7 @@
 //! and parse the [`http::Response`] with [`GetPollsRequest::parse_response(None, &request.get_uri(), response)`](GetPollsRequest::parse_response)
 
 use super::*;
-use helix::RequestGet;
+use helix::{PaginationState, RequestGet};
 pub use types::{PollChoice, PollStatus};
 
 /// Query Parameters for [Get polls](super::get_polls)
@@ -116,6 +116,7 @@ pub struct Poll {
 }
 
 impl Request for GetPollsRequest<'_> {
+    type PaginationData = PaginationState<Self>;
     type Response = Vec<Poll>;
 
     const PATH: &'static str = "polls";

--- a/src/helix/endpoints/predictions/create_prediction.rs
+++ b/src/helix/endpoints/predictions/create_prediction.rs
@@ -154,6 +154,7 @@ impl<'a> NewPredictionOutcome<'a> {
 pub type CreatePredictionResponse = super::Prediction;
 
 impl Request for CreatePredictionRequest<'_> {
+    type PaginationData = ();
     type Response = CreatePredictionResponse;
 
     const PATH: &'static str = "predictions";
@@ -166,7 +167,7 @@ impl<'a> RequestPost for CreatePredictionRequest<'a> {
     type Body = CreatePredictionBody<'a>;
 
     fn parse_inner_response(
-        request: Option<Self>,
+        _request: Option<Self>,
         uri: &http::Uri,
         response_str: &str,
         status: http::StatusCode,
@@ -193,9 +194,7 @@ impl<'a> RequestPost for CreatePredictionRequest<'a> {
         })?;
         Ok(helix::Response {
             data,
-            pagination: response.pagination.cursor,
-            request,
-            total: None,
+            pagination_data: (),
             other: None,
         })
     }

--- a/src/helix/endpoints/predictions/end_prediction.rs
+++ b/src/helix/endpoints/predictions/end_prediction.rs
@@ -150,6 +150,7 @@ pub enum EndPrediction {
 }
 
 impl Request for EndPredictionRequest<'_> {
+    type PaginationData = ();
     type Response = EndPrediction;
 
     const PATH: &'static str = "predictions";

--- a/src/helix/endpoints/predictions/get_predictions.rs
+++ b/src/helix/endpoints/predictions/get_predictions.rs
@@ -36,7 +36,7 @@
 //! and parse the [`http::Response`] with [`GetPredictionsRequest::parse_response(None, &request.get_uri(), response)`](GetPredictionsRequest::parse_response)
 
 use super::*;
-use helix::RequestGet;
+use helix::{PaginationState, RequestGet};
 pub use types::{PredictionOutcome, PredictionOutcomeId, PredictionStatus};
 
 /// Query Parameters for [Get predictions](super::get_predictions)
@@ -121,6 +121,7 @@ pub struct Prediction {
 }
 
 impl Request for GetPredictionsRequest<'_> {
+    type PaginationData = PaginationState<Self>;
     type Response = Vec<Prediction>;
 
     const PATH: &'static str = "predictions";

--- a/src/helix/endpoints/raids/cancel_a_raid.rs
+++ b/src/helix/endpoints/raids/cancel_a_raid.rs
@@ -69,6 +69,7 @@ pub enum CancelARaidResponse {
 }
 
 impl Request for CancelARaidRequest<'_> {
+    type PaginationData = ();
     type Response = CancelARaidResponse;
 
     #[cfg(feature = "twitch_oauth2")]

--- a/src/helix/endpoints/raids/start_a_raid.rs
+++ b/src/helix/endpoints/raids/start_a_raid.rs
@@ -81,6 +81,7 @@ pub struct StartARaidResponse {
     is_mature: bool,
 }
 impl Request for StartARaidRequest<'_> {
+    type PaginationData = ();
     type Response = StartARaidResponse;
 
     const PATH: &'static str = "raids";
@@ -93,7 +94,7 @@ impl RequestPost for StartARaidRequest<'_> {
     type Body = helix::EmptyBody;
 
     fn parse_inner_response(
-        request: Option<Self>,
+        _request: Option<Self>,
         uri: &http::Uri,
         response_str: &str,
         status: http::StatusCode,
@@ -120,9 +121,7 @@ impl RequestPost for StartARaidRequest<'_> {
         })?;
         Ok(helix::Response {
             data,
-            pagination: response.pagination.cursor,
-            request,
-            total: None,
+            pagination_data: (),
             other: None,
         })
     }

--- a/src/helix/endpoints/schedule/create_channel_stream_schedule_segment.rs
+++ b/src/helix/endpoints/schedule/create_channel_stream_schedule_segment.rs
@@ -153,6 +153,7 @@ impl helix::private::SealedSerialize for CreateChannelStreamScheduleSegmentBody<
 pub type CreateChannelStreamScheduleSegmentResponse = ScheduledBroadcasts;
 
 impl Request for CreateChannelStreamScheduleSegmentRequest<'_> {
+    type PaginationData = ();
     type Response = CreateChannelStreamScheduleSegmentResponse;
 
     const PATH: &'static str = "schedule/segment";

--- a/src/helix/endpoints/schedule/delete_channel_stream_schedule_segment.rs
+++ b/src/helix/endpoints/schedule/delete_channel_stream_schedule_segment.rs
@@ -87,6 +87,7 @@ pub enum DeleteChannelStreamScheduleSegment {
 }
 
 impl Request for DeleteChannelStreamScheduleSegmentRequest<'_> {
+    type PaginationData = ();
     type Response = DeleteChannelStreamScheduleSegment;
 
     const PATH: &'static str = "schedule/segment";

--- a/src/helix/endpoints/schedule/get_channel_stream_schedule.rs
+++ b/src/helix/endpoints/schedule/get_channel_stream_schedule.rs
@@ -38,7 +38,7 @@
 //! and parse the [`http::Response`] with [`GetChannelStreamScheduleRequest::parse_response(None, &request.get_uri(), response)`](GetChannelStreamScheduleRequest::parse_response)
 
 use super::*;
-use helix::RequestGet;
+use helix::{PaginationState, RequestGet};
 
 /// Query Parameters for [Get Channel Stream Schedule](super::get_channel_stream_schedule)
 ///
@@ -120,6 +120,7 @@ impl<'a> GetChannelStreamScheduleRequest<'a> {
 pub type GetChannelStreamScheduleResponse = ScheduledBroadcasts;
 
 impl Request for GetChannelStreamScheduleRequest<'_> {
+    type PaginationData = PaginationState<Self>;
     type Response = ScheduledBroadcasts;
 
     const PATH: &'static str = "schedule";

--- a/src/helix/endpoints/schedule/update_channel_stream_schedule.rs
+++ b/src/helix/endpoints/schedule/update_channel_stream_schedule.rs
@@ -97,6 +97,7 @@ pub enum UpdateChannelStreamSchedule {
 }
 
 impl Request for UpdateChannelStreamScheduleRequest<'_> {
+    type PaginationData = ();
     type Response = UpdateChannelStreamSchedule;
 
     const PATH: &'static str = "schedule/settings";

--- a/src/helix/endpoints/schedule/update_channel_stream_schedule_segment.rs
+++ b/src/helix/endpoints/schedule/update_channel_stream_schedule_segment.rs
@@ -134,6 +134,7 @@ impl helix::private::SealedSerialize for UpdateChannelStreamScheduleSegmentBody<
 pub type UpdateChannelStreamScheduleSegmentResponse = ScheduledBroadcasts;
 
 impl Request for UpdateChannelStreamScheduleSegmentRequest<'_> {
+    type PaginationData = ();
     type Response = UpdateChannelStreamScheduleSegmentResponse;
 
     const PATH: &'static str = "schedule/segment";
@@ -146,7 +147,7 @@ impl<'a> RequestPatch for UpdateChannelStreamScheduleSegmentRequest<'a> {
     type Body = UpdateChannelStreamScheduleSegmentBody<'a>;
 
     fn parse_inner_response(
-        request: Option<Self>,
+        _request: Option<Self>,
         uri: &http::Uri,
         response: &str,
         status: http::StatusCode,
@@ -163,13 +164,7 @@ impl<'a> RequestPatch for UpdateChannelStreamScheduleSegmentRequest<'a> {
                     status,
                 )
             })?;
-        Ok(helix::Response::new(
-            response.data,
-            response.pagination.cursor,
-            request,
-            response.total,
-            response.other,
-        ))
+        Ok(helix::Response::new(response.data, (), response.other))
     }
 }
 

--- a/src/helix/endpoints/search/search_categories.rs
+++ b/src/helix/endpoints/search/search_categories.rs
@@ -33,7 +33,7 @@
 //! You can also get the [`http::Request`] with [`request.create_request(&token, &client_id)`](helix::RequestGet::create_request)
 //! and parse the [`http::Response`] with [`SearchCategoriesRequest::parse_response(None, &request.get_uri(), response)`](SearchCategoriesRequest::parse_response)
 use super::*;
-use helix::RequestGet;
+use helix::{pagination::PaginationData, PaginationState, RequestGet};
 
 // FIXME: One of id, user_id or game_id needs to be specified. typed_builder should have enums. id can not be used with other params
 /// Query Parameters for [Search Categories](super::search_categories)
@@ -85,6 +85,7 @@ impl<'a> SearchCategoriesRequest<'a> {
 pub type Category = types::TwitchCategory;
 
 impl Request for SearchCategoriesRequest<'_> {
+    type PaginationData = PaginationState<Self>;
     type Response = Vec<Category>;
 
     const PATH: &'static str = "search/categories";
@@ -113,9 +114,7 @@ impl RequestGet for SearchCategoriesRequest<'_> {
             })?;
         Ok(helix::Response::new(
             response.data.unwrap_or_default(),
-            response.pagination.cursor,
-            request,
-            response.total,
+            PaginationState::new(response.pagination.cursor, request, response.total),
             response.other,
         ))
     }

--- a/src/helix/endpoints/search/search_channels.rs
+++ b/src/helix/endpoints/search/search_channels.rs
@@ -35,7 +35,7 @@
 //! and parse the [`http::Response`] with [`SearchChannelsRequest::parse_response(None, &request.get_uri(), response)`](SearchChannelsRequest::parse_response)
 
 use super::*;
-use helix::RequestGet;
+use helix::{PaginationState, RequestGet};
 
 /// Query Parameters for [Search Channels](super::search_channels)
 ///
@@ -125,6 +125,7 @@ pub struct Channel {
 }
 
 impl Request for SearchChannelsRequest<'_> {
+    type PaginationData = PaginationState<Self>;
     type Response = Vec<Channel>;
 
     const PATH: &'static str = "search/channels";

--- a/src/helix/endpoints/streams/create_stream_marker.rs
+++ b/src/helix/endpoints/streams/create_stream_marker.rs
@@ -137,6 +137,7 @@ pub struct CreatedStreamMarker {
 }
 
 impl Request for CreateStreamMarkerRequest<'_> {
+    type PaginationData = ();
     type Response = CreatedStreamMarker;
 
     const PATH: &'static str = "streams/markers";

--- a/src/helix/endpoints/streams/get_followed_streams.rs
+++ b/src/helix/endpoints/streams/get_followed_streams.rs
@@ -39,7 +39,7 @@
 //! and parse the [`http::Response`] with [`GetFollowedStreamsRequest::parse_response(None, &request.get_uri(), response)`](GetFollowedStreamsRequest::parse_response)
 
 use super::*;
-use helix::RequestGet;
+use helix::{PaginationState, RequestGet};
 
 /// Query Parameters for [Get Followed Streams](super::get_followed_streams)
 ///
@@ -94,6 +94,7 @@ impl<'a> GetFollowedStreamsRequest<'a> {
 pub type GetFollowedStreamsResponse = Stream;
 
 impl Request for GetFollowedStreamsRequest<'_> {
+    type PaginationData = PaginationState<Self>;
     type Response = Vec<GetFollowedStreamsResponse>;
 
     const PATH: &'static str = "streams/followed";

--- a/src/helix/endpoints/streams/get_stream_key.rs
+++ b/src/helix/endpoints/streams/get_stream_key.rs
@@ -70,6 +70,7 @@ pub struct GetStreamKeyResponse {
 }
 
 impl Request for GetStreamKeyRequest<'_> {
+    type PaginationData = ();
     type Response = GetStreamKeyResponse;
 
     const PATH: &'static str = "streams/key";

--- a/src/helix/endpoints/streams/get_stream_markers.rs
+++ b/src/helix/endpoints/streams/get_stream_markers.rs
@@ -41,7 +41,7 @@
 //! and parse the [`http::Response`] with [`GetStreamMarkersRequest::parse_response(None, &request.get_uri(), response)`](GetStreamMarkersRequest::parse_response)
 
 use super::*;
-use helix::RequestGet;
+use helix::{PaginationState, RequestGet};
 
 /// Query Parameters for [Get Stream Markers](super::get_stream_markers)
 ///
@@ -152,6 +152,7 @@ pub struct StreamMarker {
 }
 
 impl Request for GetStreamMarkersRequest<'_> {
+    type PaginationData = PaginationState<Self>;
     type Response = Vec<StreamMarkerGroup>;
 
     const PATH: &'static str = "streams/markers";

--- a/src/helix/endpoints/streams/get_stream_tags.rs
+++ b/src/helix/endpoints/streams/get_stream_tags.rs
@@ -67,6 +67,7 @@ impl<'a> GetStreamTagsRequest<'a> {
 pub type Tag = helix::tags::TwitchTag;
 
 impl Request for GetStreamTagsRequest<'_> {
+    type PaginationData = ();
     type Response = Vec<Tag>;
 
     const PATH: &'static str = "streams/tags";

--- a/src/helix/endpoints/streams/get_streams.rs
+++ b/src/helix/endpoints/streams/get_streams.rs
@@ -41,7 +41,7 @@
 //! and parse the [`http::Response`] with [`GetStreamsRequest::parse_response(None, &request.get_uri(), response)`](GetStreamsRequest::parse_response)
 
 use super::*;
-use helix::RequestGet;
+use helix::{PaginationState, RequestGet};
 
 /// Query Parameters for [Get Streams](super::get_streams)
 ///
@@ -183,6 +183,7 @@ pub struct Stream {
 }
 
 impl Request for GetStreamsRequest<'_> {
+    type PaginationData = PaginationState<Self>;
     type Response = Vec<Stream>;
 
     const PATH: &'static str = "streams";

--- a/src/helix/endpoints/streams/replace_stream_tags.rs
+++ b/src/helix/endpoints/streams/replace_stream_tags.rs
@@ -130,6 +130,7 @@ pub enum ReplaceStreamTags {
 impl helix::private::SealedSerialize for ReplaceStreamTagsBody<'_> {}
 
 impl Request for ReplaceStreamTagsRequest<'_> {
+    type PaginationData = ();
     type Response = ReplaceStreamTags;
 
     const PATH: &'static str = "streams/tags";
@@ -142,7 +143,7 @@ impl<'a> RequestPut for ReplaceStreamTagsRequest<'a> {
     type Body = ReplaceStreamTagsBody<'a>;
 
     fn parse_inner_response(
-        request: Option<Self>,
+        _request: Option<Self>,
         uri: &http::Uri,
         response: &str,
         status: http::StatusCode,
@@ -153,9 +154,7 @@ impl<'a> RequestPut for ReplaceStreamTagsRequest<'a> {
         match status {
             http::StatusCode::NO_CONTENT | http::StatusCode::OK => Ok(helix::Response::new(
                 ReplaceStreamTags::Success,
-                None,
-                request,
-                None,
+                (),
                 <_>::default(),
             )),
             _ => Err(helix::HelixRequestPutError::InvalidResponse {

--- a/src/helix/endpoints/subscriptions/check_user_subscription.rs
+++ b/src/helix/endpoints/subscriptions/check_user_subscription.rs
@@ -98,6 +98,7 @@ pub struct UserSubscription {
 }
 
 impl Request for CheckUserSubscriptionRequest<'_> {
+    type PaginationData = ();
     type Response = UserSubscription;
 
     const PATH: &'static str = "subscriptions/user";
@@ -108,7 +109,7 @@ impl Request for CheckUserSubscriptionRequest<'_> {
 
 impl RequestGet for CheckUserSubscriptionRequest<'_> {
     fn parse_inner_response(
-        request: Option<Self>,
+        _request: Option<Self>,
         uri: &http::Uri,
         text: &str,
         status: http::StatusCode,
@@ -134,9 +135,7 @@ impl RequestGet for CheckUserSubscriptionRequest<'_> {
                     uri: uri.clone(),
                 },
             )?,
-            inner_response.pagination.cursor,
-            request,
-            inner_response.total,
+            (),
             inner_response.other,
         ))
     }

--- a/src/helix/endpoints/subscriptions/get_broadcaster_subscriptions.rs
+++ b/src/helix/endpoints/subscriptions/get_broadcaster_subscriptions.rs
@@ -36,7 +36,7 @@
 //! and parse the [`http::Response`] with [`GetBroadcasterSubscriptionsRequest::parse_response(None, &request.get_uri(), response)`](GetBroadcasterSubscriptionsRequest::parse_response)
 
 use super::*;
-use helix::RequestGet;
+use helix::{PaginationState, RequestGet};
 
 /// Query Parameters for [Get Broadcaster Subscriptions](super::get_broadcaster_subscriptions)
 ///
@@ -135,6 +135,7 @@ pub struct BroadcasterSubscription {
 }
 
 impl Request for GetBroadcasterSubscriptionsRequest<'_> {
+    type PaginationData = PaginationState<Self>;
     type Response = Vec<BroadcasterSubscription>;
 
     const PATH: &'static str = "subscriptions";
@@ -222,6 +223,6 @@ fn test_request() {
             GetBroadcasterSubscriptionsRequest::parse_response(Some(req), &uri, http_response)
                 .unwrap()
         );
-    assert_eq!(resp.total, Some(13));
+    assert_eq!(resp.pagination_data.total, Some(13));
     assert_eq!(resp.points().unwrap(), 13);
 }

--- a/src/helix/endpoints/subscriptions/get_broadcaster_subscriptions_events.rs
+++ b/src/helix/endpoints/subscriptions/get_broadcaster_subscriptions_events.rs
@@ -42,7 +42,7 @@
 // FIXME: Twitch docs sucks... This entire endpoint is removed from docs
 
 use super::*;
-use helix::RequestGet;
+use helix::{PaginationState, RequestGet};
 
 /// Query Parameters for [Get Broadcaster Subscriptions Events](super::get_broadcaster_subscriptions_events)
 ///
@@ -179,6 +179,7 @@ where D: serde::de::Deserializer<'de> {
 }
 
 impl Request for GetBroadcasterSubscriptionsEventsRequest<'_> {
+    type PaginationData = PaginationState<Self>;
     type Response = Vec<BroadcasterSubscriptionEvent>;
 
     const PATH: &'static str = "subscriptions/events";

--- a/src/helix/endpoints/tags/get_all_stream_tags.rs
+++ b/src/helix/endpoints/tags/get_all_stream_tags.rs
@@ -35,7 +35,7 @@
 //! and parse the [`http::Response`] with [`GetAllStreamTagsRequest::parse_response(None, &request.get_uri(), response)`](GetAllStreamTagsRequest::parse_response)
 #![allow(deprecated)]
 use super::*;
-use helix::RequestGet;
+use helix::{PaginationState, RequestGet};
 
 /// Query Parameters for [Get All Stream Tags](super::get_all_stream_tags)
 ///
@@ -83,6 +83,7 @@ impl<'a> GetAllStreamTagsRequest<'a> {
 pub type Tag = helix::tags::TwitchTag;
 
 impl Request for GetAllStreamTagsRequest<'_> {
+    type PaginationData = PaginationState<Self>;
     type Response = Vec<Tag>;
 
     const PATH: &'static str = "tags/streams";

--- a/src/helix/endpoints/teams/get_channel_teams.rs
+++ b/src/helix/endpoints/teams/get_channel_teams.rs
@@ -77,6 +77,7 @@ pub struct BroadcasterTeam {
 }
 
 impl Request for GetChannelTeamsRequest<'_> {
+    type PaginationData = ();
     type Response = Vec<BroadcasterTeam>;
 
     #[cfg(feature = "twitch_oauth2")]
@@ -88,7 +89,7 @@ impl Request for GetChannelTeamsRequest<'_> {
 
 impl RequestGet for GetChannelTeamsRequest<'_> {
     fn parse_inner_response(
-        request: Option<Self>,
+        _request: Option<Self>,
         uri: &http::Uri,
         response: &str,
         status: http::StatusCode,
@@ -107,9 +108,7 @@ impl RequestGet for GetChannelTeamsRequest<'_> {
             })?;
         Ok(helix::Response::new(
             response.data.unwrap_or_default(),
-            response.pagination.cursor,
-            request,
-            response.total,
+            (),
             response.other,
         ))
     }

--- a/src/helix/endpoints/teams/get_teams.rs
+++ b/src/helix/endpoints/teams/get_teams.rs
@@ -85,6 +85,7 @@ pub struct Team {
 }
 
 impl Request for GetTeamsRequest<'_> {
+    type PaginationData = ();
     type Response = Vec<Team>;
 
     #[cfg(feature = "twitch_oauth2")]

--- a/src/helix/endpoints/users/block_user.rs
+++ b/src/helix/endpoints/users/block_user.rs
@@ -118,6 +118,7 @@ pub enum BlockUser {
 }
 
 impl Request for BlockUserRequest<'_> {
+    type PaginationData = ();
     type Response = BlockUser;
 
     #[cfg(feature = "twitch_oauth2")]

--- a/src/helix/endpoints/users/get_user_active_extensions.rs
+++ b/src/helix/endpoints/users/get_user_active_extensions.rs
@@ -121,6 +121,7 @@ pub struct ActivePositionedExtension {
 }
 
 impl Request for GetUserActiveExtensionsRequest<'_> {
+    type PaginationData = ();
     type Response = ExtensionConfiguration;
 
     #[cfg(feature = "twitch_oauth2")]

--- a/src/helix/endpoints/users/get_user_block_list.rs
+++ b/src/helix/endpoints/users/get_user_block_list.rs
@@ -34,7 +34,7 @@
 //! and parse the [`http::Response`] with [`GetUserBlockListRequest::parse_response(None, &request.get_uri(), response)`](GetUserBlockListRequest::parse_response)
 
 use super::*;
-use helix::RequestGet;
+use helix::{PaginationState, RequestGet};
 
 /// Query Parameters for [Get Users Block List](super::get_user_block_list)
 ///
@@ -84,6 +84,7 @@ pub struct UserBlock {
 }
 
 impl Request for GetUserBlockListRequest<'_> {
+    type PaginationData = PaginationState<Self>;
     type Response = Vec<UserBlock>;
 
     #[cfg(feature = "twitch_oauth2")]

--- a/src/helix/endpoints/users/get_user_extensions.rs
+++ b/src/helix/endpoints/users/get_user_extensions.rs
@@ -91,6 +91,7 @@ pub enum ExtensionType {
 }
 
 impl Request for GetUserExtensionsRequest {
+    type PaginationData = ();
     type Response = Vec<Extension>;
 
     #[cfg(feature = "twitch_oauth2")]

--- a/src/helix/endpoints/users/get_users.rs
+++ b/src/helix/endpoints/users/get_users.rs
@@ -139,6 +139,7 @@ pub struct User {
 }
 
 impl Request for GetUsersRequest<'_> {
+    type PaginationData = ();
     type Response = Vec<User>;
 
     #[cfg(feature = "twitch_oauth2")]

--- a/src/helix/endpoints/users/get_users_follows.rs
+++ b/src/helix/endpoints/users/get_users_follows.rs
@@ -32,7 +32,7 @@
 //! and parse the [`http::Response`] with [`GetUsersFollowsRequest::parse_response(None, &request.get_uri(), response)`](GetUsersFollowsRequest::parse_response)
 
 use super::*;
-use helix::RequestGet;
+use helix::{pagination::PaginationData, PaginationState, RequestGet};
 /// Query Parameters for [Get Users Follows](super::get_users_follows)
 ///
 /// [`get-users-follows`](https://dev.twitch.tv/docs/api/reference#get-users-follows)
@@ -147,6 +147,7 @@ pub struct FollowRelationship {
 }
 
 impl Request for GetUsersFollowsRequest<'_> {
+    type PaginationData = PaginationState<Self>;
     type Response = UsersFollows;
 
     #[cfg(feature = "twitch_oauth2")]
@@ -187,9 +188,7 @@ impl RequestGet for GetUsersFollowsRequest<'_> {
                 total: response.total,
                 follow_relationships: response.data,
             },
-            response.pagination.cursor,
-            request,
-            Some(response.total),
+            PaginationState::new(response.pagination.cursor, request, Some(response.total)),
             None,
         ))
     }

--- a/src/helix/endpoints/users/unblock_user.rs
+++ b/src/helix/endpoints/users/unblock_user.rs
@@ -69,6 +69,7 @@ pub enum UnblockUser {
 }
 
 impl Request for UnblockUserRequest<'_> {
+    type PaginationData = ();
     type Response = UnblockUser;
 
     #[cfg(feature = "twitch_oauth2")]

--- a/src/helix/endpoints/users/update_user.rs
+++ b/src/helix/endpoints/users/update_user.rs
@@ -71,6 +71,7 @@ impl<'a> UpdateUserRequest<'a> {
 }
 
 impl Request for UpdateUserRequest<'_> {
+    type PaginationData = ();
     type Response = User;
 
     const PATH: &'static str = "users";

--- a/src/helix/endpoints/users/update_user_extensions.rs
+++ b/src/helix/endpoints/users/update_user_extensions.rs
@@ -84,6 +84,7 @@ impl UpdateUserExtensionsRequest<'_> {
 }
 
 impl Request for UpdateUserExtensionsRequest<'_> {
+    type PaginationData = ();
     type Response = ExtensionConfiguration;
 
     const PATH: &'static str = "users/extensions";
@@ -223,7 +224,7 @@ impl<'a> RequestPut for UpdateUserExtensionsRequest<'a> {
     type Body = UpdateUserExtensionsBody<'a>;
 
     fn parse_inner_response(
-        request: Option<Self>,
+        _request: Option<Self>,
         uri: &http::Uri,
         response: &str,
         status: http::StatusCode,
@@ -242,9 +243,7 @@ impl<'a> RequestPut for UpdateUserExtensionsRequest<'a> {
             })?;
         Ok(helix::Response::new(
             inner_response.data,
-            inner_response.pagination.cursor,
-            request,
-            inner_response.total,
+            (),
             inner_response.other,
         ))
     }

--- a/src/helix/endpoints/videos/delete_videos.rs
+++ b/src/helix/endpoints/videos/delete_videos.rs
@@ -74,6 +74,7 @@ pub enum DeleteVideo {
 }
 
 impl Request for DeleteVideosRequest<'_> {
+    type PaginationData = ();
     type Response = DeleteVideo;
 
     const PATH: &'static str = "videos";

--- a/src/helix/endpoints/videos/get_videos.rs
+++ b/src/helix/endpoints/videos/get_videos.rs
@@ -34,7 +34,7 @@
 //! and parse the [`http::Response`] with [`GetVideosRequest::parse_response(None, &request.get_uri(), response)`](GetVideosRequest::parse_response)
 
 use super::*;
-use helix::RequestGet;
+use helix::{PaginationState, RequestGet};
 
 // FIXME: One of id, user_id or game_id needs to be specified. typed_builder should have enums. id can not be used with other params
 /// Query Parameters for [Get Videos](super::get_videos)
@@ -172,6 +172,7 @@ pub struct MutedSegment {
 }
 
 impl Request for GetVideosRequest<'_> {
+    type PaginationData = PaginationState<Self>;
     type Response = Vec<Video>;
 
     const PATH: &'static str = "videos";

--- a/src/helix/endpoints/whispers/send_whisper.rs
+++ b/src/helix/endpoints/whispers/send_whisper.rs
@@ -123,6 +123,7 @@ pub enum SendWhisperResponse {
 }
 
 impl Request for SendWhisperRequest<'_> {
+    type PaginationData = ();
     type Response = SendWhisperResponse;
 
     const PATH: &'static str = "whispers";

--- a/src/helix/mod.rs
+++ b/src/helix/mod.rs
@@ -397,6 +397,7 @@ use twitch_oauth2::TwitchToken;
 #[cfg(feature = "client")]
 pub mod client;
 mod endpoints;
+pub mod pagination;
 pub mod request;
 pub mod response;
 
@@ -416,6 +417,9 @@ pub use request::errors::{
 pub use request::{Request, RequestDelete, RequestGet, RequestPatch, RequestPost, RequestPut};
 #[doc(inline)]
 pub use response::Response;
+
+#[doc(inline)]
+pub use pagination::PaginationState;
 
 pub(crate) mod ser;
 pub(crate) use crate::deserialize_default_from_null;
@@ -520,7 +524,8 @@ where
 }
 
 /// A request that can be paginated.
-pub trait Paginated: Request {
+pub trait Paginated: Request<PaginationData = PaginationState<Self>>
+where Self: Sized {
     /// Should returns the current pagination cursor.
     ///
     /// # Notes

--- a/src/helix/pagination.rs
+++ b/src/helix/pagination.rs
@@ -1,0 +1,43 @@
+//! Types used for paginated requests
+
+use std::fmt::Debug;
+
+use super::{Cursor, Request};
+
+/// The state of a paginated request
+#[derive(PartialEq, Eq, Debug)]
+pub struct PaginationState<R: Request> {
+    /// A cursor value, to be used in a subsequent request to specify the starting point of the next set of results.
+    pub cursor: Option<Cursor>,
+    /// The request that was sent, used for [pagination](super::Paginated).
+    pub request: Option<R>,
+    /// Response would return this many results if fully paginated. Sometimes this is not emmitted or correct for this purpose, in those cases, this value will be `None`.
+    pub total: Option<i64>,
+}
+
+/// Data used to keep track of the pagination for a request.
+pub trait PaginationData<R: Request> {
+    /// Create the state for a response and its request
+    fn new(cursor: Option<Cursor>, request: Option<R>, total: Option<i64>) -> Self;
+
+    /// Get the total number of items in the data
+    fn total(&self) -> Option<i64>;
+}
+
+impl<R: Request> PaginationData<R> for () {
+    fn new(_cursor: Option<Cursor>, _request: Option<R>, _total: Option<i64>) -> Self {}
+
+    fn total(&self) -> Option<i64> { None }
+}
+
+impl<R: Request> PaginationData<R> for PaginationState<R> {
+    fn new(cursor: Option<Cursor>, request: Option<R>, total: Option<i64>) -> Self {
+        Self {
+            cursor,
+            request,
+            total,
+        }
+    }
+
+    fn total(&self) -> Option<i64> { self.total }
+}


### PR DESCRIPTION
This tries to do what I wanted in https://github.com/twitch-rs/twitch_api/pull/502#issuecomment-3371372016.

Currently, helix responses always contain pagination data even if they're not paginated: https://github.com/twitch-rs/twitch_api/blob/90b395bc02d0c3ec554eb6a53278e1cbf8675efc/src/helix/response.rs#L13-L18

Ideally, these fields would only be present for requests that are `Paginated`. However, we can't determine this - we can't make a type "conditional" on whether it implements a trait or not (maybe that's C++ brained).

Since we already depend on the request type in the `Response`, we can specify the state needed for the pagination in `Request`. For non-paginated requests, we use `()` and for paginated ones `PaginationState<Self>` (a new type that holds the cursor, request, and total). Unfortunately, types can't be defaulted in traits yet, so the type has to be specified for every request.

I'm not sure if there's a simpler way to do this.