### PR TITLE
Add chat_user_banned as possible status for get eventsub subscriptions endpoint

### DIFF
--- a/src/eventsub/mod.rs
+++ b/src/eventsub/mod.rs
@@ -909,7 +909,7 @@ pub enum Status {
     /// Twitch revoked your subscription because the users in the [`condition`](EventSubSubscription::condition) object are no longer Twitch users.
     #[serde(rename = "user_removed")]
     UserRemoved,
-    /// Twitch revoked your subscription because the user was banned in the broadcaster's channel
+    /// The user specified in the [`condition`](EventSubSubscription::condition) object was banned from the broadcaster's chat.
     #[serde(rename = "chat_user_banned")]
     ChatUserBanned,
     /// Twitch revoked your subscription because the subscribed to subscription type and version is no longer supported.

--- a/src/eventsub/mod.rs
+++ b/src/eventsub/mod.rs
@@ -909,6 +909,9 @@ pub enum Status {
     /// Twitch revoked your subscription because the users in the [`condition`](EventSubSubscription::condition) object are no longer Twitch users.
     #[serde(rename = "user_removed")]
     UserRemoved,
+    /// Twitch revoked your subscription because the user was banned in the broadcaster's channel
+    #[serde(rename = "chat_user_banned")]
+    ChatUserBanned,
     /// Twitch revoked your subscription because the subscribed to subscription type and version is no longer supported.
     #[serde(rename = "version_removed")]
     VersionRemoved,


### PR DESCRIPTION
Fixes deserializing eventsubs if user account got banned in the broadcaster's channel

Getting this problem after the chat user was banned by sery_bot, then unbanned by broadcaster, so figured I'd just fix it upstream.

ref:
Error("unknown variant `chat_user_banned`, expected one of `enabled`, `webhook_callback_verification_pending`, `webhook_callback_verification_failed`, `notification_failures_exceeded`, `authorization_revoked`, `moderator_removed`, `user_removed`, `version_removed`, `beta_maintenance`, `websocket_disconnected`, `websocket_failed_ping_pong`, `websocket_received_inbound_traffic`, `websocket_connection_unused`, `websocket_internal_error`, `websocket_network_timeout`, `websocket_network_error`, `websocket_failed_to_reconnect`")