### PR TITLE
feat(helix): Add suspicious status updates

### DIFF
--- a/src/helix/client/client_ext.rs
+++ b/src/helix/client/client_ext.rs
@@ -990,6 +990,31 @@ impl<'client, C: crate::HttpClient + Sync + 'client> HelixClient<'client, C> {
             .data)
     }
 
+    /// Add a suspicious user status to a chatter on the broadcaster’s channel.
+    pub async fn add_suspicious_status_to_chat_user<'b, T>(
+        &'client self,
+        user_id: impl types::IntoCow<'b, types::UserIdRef> + Send + 'b,
+        status: helix::moderation::AddedSuspiciousUserStatus,
+        broadcaster_id: impl types::IntoCow<'b, types::UserIdRef> + Send + 'b,
+        moderator_id: impl types::IntoCow<'b, types::UserIdRef> + Send + 'b,
+        token: &T,
+    ) -> Result<helix::moderation::SuspiciousUserInfo, ClientError<C>>
+    where
+        T: TwitchToken + Send + Sync + ?Sized,
+    {
+        Ok(self
+            .req_post(
+                helix::moderation::AddSuspiciousStatusToChatUserRequest::new(
+                    broadcaster_id,
+                    moderator_id,
+                ),
+                helix::moderation::AddSuspiciousStatusToChatUserBody::new(user_id, status),
+                token,
+            )
+            .await?
+            .data)
+    }
+
     // FIXME: Example should use https://github.com/twitch-rs/twitch_api/issues/162
     /// Get all scheduled streams in a channel.
     ///

--- a/src/helix/client/client_ext.rs
+++ b/src/helix/client/client_ext.rs
@@ -1015,6 +1015,30 @@ impl<'client, C: crate::HttpClient + Sync + 'client> HelixClient<'client, C> {
             .data)
     }
 
+    /// Remove a suspicious user status from a chatter on broadcaster’s channel.
+    pub async fn remove_suspicious_status_from_chat_user<'b, T>(
+        &'client self,
+        user_id: impl types::IntoCow<'b, types::UserIdRef> + Send + 'b,
+        broadcaster_id: impl types::IntoCow<'b, types::UserIdRef> + Send + 'b,
+        moderator_id: impl types::IntoCow<'b, types::UserIdRef> + Send + 'b,
+        token: &T,
+    ) -> Result<helix::moderation::SuspiciousUserInfo, ClientError<C>>
+    where
+        T: TwitchToken + Send + Sync + ?Sized,
+    {
+        Ok(self
+            .req_delete(
+                helix::moderation::RemoveSuspiciousStatusFromChatUserRequest::new(
+                    broadcaster_id,
+                    moderator_id,
+                    user_id,
+                ),
+                token,
+            )
+            .await?
+            .data)
+    }
+
     // FIXME: Example should use https://github.com/twitch-rs/twitch_api/issues/162
     /// Get all scheduled streams in a channel.
     ///

--- a/src/helix/endpoints/moderation/add_suspicious_status_to_chat_user.rs
+++ b/src/helix/endpoints/moderation/add_suspicious_status_to_chat_user.rs
@@ -1,0 +1,195 @@
+//! Adds a suspicious user status to a chatter on the broadcaster’s channel.
+//! [`add-suspicious-status-to-chat-user`](https://dev.twitch.tv/docs/api/reference#add-suspicious-status-to-chat-user)
+//!
+//! # Accessing the endpoint
+//!
+//! ## Request: [AddSuspiciousStatusToChatUserRequest]
+//!
+//! To use this endpoint, construct a [`AddSuspiciousStatusToChatUserRequest`] with the [`AddSuspiciousStatusToChatUserRequest::new()`] method.
+//!
+//! ```rust
+//! use twitch_api::helix::moderation::add_suspicious_status_to_chat_user;
+//! let request = add_suspicious_status_to_chat_user::AddSuspiciousStatusToChatUserRequest::new("1234", "5678");
+//! ```
+//!
+//! ## Body: [AddSuspiciousStatusToChatUserBody]
+//!
+//! We also need to provide a body to the request containing what we want to change.
+//!
+//! ```
+//! # use twitch_api::helix::moderation::{add_suspicious_status_to_chat_user, AddedSuspiciousUserStatus};
+//! let body = add_suspicious_status_to_chat_user::AddSuspiciousStatusToChatUserBody::new("9876", AddedSuspiciousUserStatus::Restricted);
+//! ```
+//!
+//! ## Response: [SuspiciousUserInfo]
+//!
+//! Send the request to receive the response with [`HelixClient::req_post()`](helix::HelixClient::req_post).
+//!
+//! ```rust, no_run
+//! use twitch_api::helix::{self, moderation::{add_suspicious_status_to_chat_user, AddedSuspiciousUserStatus, SuspiciousUserInfo}};
+//! # use twitch_api::client;
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+//! # let client: helix::HelixClient<'static, client::DummyHttpClient> = helix::HelixClient::default();
+//! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
+//! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
+//! let request = add_suspicious_status_to_chat_user::AddSuspiciousStatusToChatUserRequest::new("1234", "5678");
+//! let body = add_suspicious_status_to_chat_user::AddSuspiciousStatusToChatUserBody::new("9876", AddedSuspiciousUserStatus::Restricted);
+//! let response: SuspiciousUserInfo = client.req_post(request, body, &token).await?.data;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! You can also get the [`http::Request`] with [`request.create_request(&token, &client_id)`](helix::RequestPost::create_request)
+//! and parse the [`http::Response`] with [`AddSuspiciousStatusToChatUserRequest::parse_response(None, &request.get_uri(), response)`](AddSuspiciousStatusToChatUserRequest::parse_response)
+
+use super::*;
+use helix::RequestPost;
+/// Query Parameters for [Add Suspicious Status to Chat User](super::add_suspicious_status_to_chat_user)
+///
+/// [`add-suspicious-status-to-chat-user`](https://dev.twitch.tv/docs/api/reference#add-suspicious-status-to-chat-user)
+#[derive(PartialEq, Eq, Deserialize, Serialize, Clone, Debug)]
+#[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
+#[must_use]
+#[non_exhaustive]
+pub struct AddSuspiciousStatusToChatUserRequest<'a> {
+    /// The user ID of the broadcaster, indicating the channel where the status is being applied.
+    #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
+    #[cfg_attr(feature = "deser_borrow", serde(borrow = "'a"))]
+    pub broadcaster_id: Cow<'a, types::UserIdRef>,
+    /// The user ID of the moderator who is applying the status.
+    #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
+    #[cfg_attr(feature = "deser_borrow", serde(borrow = "'a"))]
+    pub moderator_id: Cow<'a, types::UserIdRef>,
+}
+
+impl<'a> AddSuspiciousStatusToChatUserRequest<'a> {
+    /// Add a suspicious user status to a chatter on the broadcaster’s channel.
+    pub fn new(
+        broadcaster_id: impl types::IntoCow<'a, types::UserIdRef> + 'a,
+        moderator_id: impl types::IntoCow<'a, types::UserIdRef> + 'a,
+    ) -> Self {
+        Self {
+            broadcaster_id: broadcaster_id.into_cow(),
+            moderator_id: moderator_id.into_cow(),
+        }
+    }
+}
+
+/// Body Parameters for [Add Suspicious Status to Chat User](super::add_suspicious_status_to_chat_user)
+///
+/// [`add-suspicious-status-to-chat-user`](https://dev.twitch.tv/docs/api/reference#add-suspicious-status-to-chat-user)
+#[derive(PartialEq, Eq, Deserialize, Serialize, Clone, Debug)]
+#[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
+#[non_exhaustive]
+pub struct AddSuspiciousStatusToChatUserBody<'a> {
+    /// The ID of the user being given the suspicious status.
+    #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
+    #[cfg_attr(feature = "deser_borrow", serde(borrow = "'a"))]
+    pub user_id: Cow<'a, types::UserIdRef>,
+    /// The type of suspicious status.
+    pub status: AddedSuspiciousUserStatus,
+}
+
+/// A user's suspicious status when adding.
+///
+/// This is the subset of valid values of [SuspiciousUserStatus] that can be specified when adding a status.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum AddedSuspiciousUserStatus {
+    /// The user is actively monitored.
+    ActiveMonitoring,
+    /// The user is restricted.
+    Restricted,
+}
+
+impl<'a> AddSuspiciousStatusToChatUserBody<'a> {
+    /// Create a new [`AddSuspiciousStatusToChatUserBody`]
+    pub fn new(
+        user_id: impl types::IntoCow<'a, types::UserIdRef> + 'a,
+        status: AddedSuspiciousUserStatus,
+    ) -> Self {
+        Self {
+            user_id: user_id.into_cow(),
+            status,
+        }
+    }
+}
+
+impl helix::private::SealedSerialize for AddSuspiciousStatusToChatUserBody<'_> {}
+
+impl Request for AddSuspiciousStatusToChatUserRequest<'_> {
+    type PaginationData = ();
+    type Response = SuspiciousUserInfo;
+
+    const PATH: &'static str = "moderation/suspicious_users";
+    #[cfg(feature = "twitch_oauth2")]
+    const SCOPE: twitch_oauth2::Validator =
+        twitch_oauth2::validator![twitch_oauth2::Scope::ModeratorManageSuspiciousUsers];
+}
+
+impl<'a> RequestPost for AddSuspiciousStatusToChatUserRequest<'a> {
+    type Body = AddSuspiciousStatusToChatUserBody<'a>;
+
+    fn parse_inner_response(
+        request: Option<Self>,
+        uri: &http::Uri,
+        response: &str,
+        status: http::StatusCode,
+    ) -> Result<helix::Response<Self, Self::Response>, helix::HelixRequestPostError>
+    where
+        Self: Sized,
+    {
+        helix::parse_single_return(request, uri, response, status)
+    }
+}
+
+#[cfg(test)]
+#[test]
+fn test_request() {
+    use helix::*;
+    let req = AddSuspiciousStatusToChatUserRequest::new("141981764", "12826");
+
+    let body =
+        AddSuspiciousStatusToChatUserBody::new("9876", AddedSuspiciousUserStatus::Restricted);
+
+    assert_eq!(
+        std::str::from_utf8(&body.try_to_body().unwrap()).unwrap(),
+        r#"{"user_id":"9876","status":"RESTRICTED"}"#
+    );
+
+    dbg!(req.create_request(body, "token", "clientid").unwrap());
+
+    // From twitch docs
+    let data = br#"
+    {
+        "data": [
+            {
+                "user_id": "9876",
+                "broadcaster_id": "141981764",
+                "moderator_id": "12826",
+                "updated_at": "2025-12-01T23:08:18+00:00",
+                "status": "RESTRICTED",
+                "types": [
+                    "MANUALLY_ADDED"
+                ]
+            }
+        ]
+    }
+    "#
+    .to_vec();
+
+    let http_response = http::Response::builder().body(data).unwrap();
+
+    let uri = req.get_uri().unwrap();
+    assert_eq!(
+        uri.to_string(),
+        "https://api.twitch.tv/helix/moderation/suspicious_users?broadcaster_id=141981764&moderator_id=12826"
+    );
+
+    dbg!(
+        AddSuspiciousStatusToChatUserRequest::parse_response(Some(req), &uri, http_response)
+            .unwrap()
+    );
+}

--- a/src/helix/endpoints/moderation/mod.rs
+++ b/src/helix/endpoints/moderation/mod.rs
@@ -5,7 +5,7 @@
 //!
 //! <!-- generate with "cargo xtask overview" (with a nightly toolchain) -->
 //! <!-- BEGIN-OVERVIEW -->
-//! <details open><summary style="cursor: pointer">Moderation 🟡 24/25</summary>
+//! <details open><summary style="cursor: pointer">Moderation 🟢 25/25</summary>
 //!
 //! | Endpoint | Helper | Module |
 //! |---|---|---|
@@ -33,7 +33,7 @@
 //! | [Get Shield Mode Status](https://dev.twitch.tv/docs/api/reference#get-shield-mode-status) | - | [`get_shield_mode_status`] |
 //! | [Warn Chat User](https://dev.twitch.tv/docs/api/reference#warn-chat-user) | [`HelixClient::warn_chat_user`](crate::helix::HelixClient::warn_chat_user) | [`warn_chat_user`] |
 //! | [Add Suspicious Status to Chat User](https://dev.twitch.tv/docs/api/reference#add-suspicious-status-to-chat-user) | [`HelixClient::add_suspicious_status_to_chat_user`](crate::helix::HelixClient::add_suspicious_status_to_chat_user) | [`add_suspicious_status_to_chat_user`] |
-//! | [Remove Suspicious Status From Chat User](https://dev.twitch.tv/docs/api/reference#remove-suspicious-status-from-chat-user) | - | - |
+//! | [Remove Suspicious Status From Chat User](https://dev.twitch.tv/docs/api/reference#remove-suspicious-status-from-chat-user) | [`HelixClient::remove_suspicious_status_from_chat_user`](crate::helix::HelixClient::remove_suspicious_status_from_chat_user) | [`remove_suspicious_status_from_chat_user`] |
 //!
 //! </details>
 //!
@@ -62,6 +62,7 @@ pub mod get_unban_requests;
 pub mod manage_held_automod_messages;
 pub mod remove_blocked_term;
 pub mod remove_channel_moderator;
+pub mod remove_suspicious_status_from_chat_user;
 pub mod resolve_unban_request;
 pub mod unban_user;
 pub mod update_automod_settings;
@@ -107,6 +108,8 @@ pub use manage_held_automod_messages::{
 pub use remove_blocked_term::{RemoveBlockedTerm, RemoveBlockedTermRequest};
 #[doc(inline)]
 pub use remove_channel_moderator::{RemoveChannelModeratorRequest, RemoveChannelModeratorResponse};
+#[doc(inline)]
+pub use remove_suspicious_status_from_chat_user::RemoveSuspiciousStatusFromChatUserRequest;
 #[doc(inline)]
 pub use resolve_unban_request::ResolveUnbanRequest;
 #[doc(inline)]

--- a/src/helix/endpoints/moderation/mod.rs
+++ b/src/helix/endpoints/moderation/mod.rs
@@ -5,7 +5,7 @@
 //!
 //! <!-- generate with "cargo xtask overview" (with a nightly toolchain) -->
 //! <!-- BEGIN-OVERVIEW -->
-//! <details open><summary style="cursor: pointer">Moderation 🟡 23/25</summary>
+//! <details open><summary style="cursor: pointer">Moderation 🟡 24/25</summary>
 //!
 //! | Endpoint | Helper | Module |
 //! |---|---|---|
@@ -32,7 +32,7 @@
 //! | [Update Shield Mode Status](https://dev.twitch.tv/docs/api/reference#update-shield-mode-status) | - | [`update_shield_mode_status`] |
 //! | [Get Shield Mode Status](https://dev.twitch.tv/docs/api/reference#get-shield-mode-status) | - | [`get_shield_mode_status`] |
 //! | [Warn Chat User](https://dev.twitch.tv/docs/api/reference#warn-chat-user) | [`HelixClient::warn_chat_user`](crate::helix::HelixClient::warn_chat_user) | [`warn_chat_user`] |
-//! | [Add Suspicious Status to Chat User](https://dev.twitch.tv/docs/api/reference#add-suspicious-status-to-chat-user) | - | - |
+//! | [Add Suspicious Status to Chat User](https://dev.twitch.tv/docs/api/reference#add-suspicious-status-to-chat-user) | [`HelixClient::add_suspicious_status_to_chat_user`](crate::helix::HelixClient::add_suspicious_status_to_chat_user) | [`add_suspicious_status_to_chat_user`] |
 //! | [Remove Suspicious Status From Chat User](https://dev.twitch.tv/docs/api/reference#remove-suspicious-status-from-chat-user) | - | - |
 //!
 //! </details>
@@ -48,6 +48,7 @@ use std::borrow::Cow;
 
 pub mod add_blocked_term;
 pub mod add_channel_moderator;
+pub mod add_suspicious_status_to_chat_user;
 pub mod ban_user;
 pub mod check_automod_status;
 pub mod delete_chat_messages;
@@ -72,6 +73,11 @@ pub mod warn_chat_user;
 pub use add_blocked_term::{AddBlockedTermBody, AddBlockedTermRequest};
 #[doc(inline)]
 pub use add_channel_moderator::{AddChannelModeratorRequest, AddChannelModeratorResponse};
+#[doc(inline)]
+pub use add_suspicious_status_to_chat_user::{
+    AddSuspiciousStatusToChatUserBody, AddSuspiciousStatusToChatUserRequest,
+    AddedSuspiciousUserStatus,
+};
 #[doc(inline)]
 pub use ban_user::{BanUser, BanUserBody, BanUserRequest};
 #[doc(inline)]
@@ -142,4 +148,58 @@ pub struct BlockedTerm {
     ///
     /// When the term is added, this timestamp is the same as created_at. The timestamp changes as AutoMod continues to deny the term.
     pub updated_at: types::Timestamp,
+}
+
+/// A user's suspicious status
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum SuspiciousUserStatus {
+    /// The user isn't suspicious.
+    NoTreatment,
+    /// The user is actively monitored.
+    ActiveMonitoring,
+    /// The user is restricted.
+    Restricted,
+
+    /// An unknown suspicious user status, contains the raw string provided by Twitch.
+    #[serde(untagged)]
+    Unknown(String),
+}
+
+/// Traits of a suspicious user
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum SuspiciousUserType {
+    /// A manually added user.
+    ManuallyAdded,
+    /// A detected ban evader.
+    DetectedBanEvader,
+    /// A detected suspicious user.
+    DetectedSusChatter,
+    /// A user banned in another channel that shares ban information.
+    BannedInSharedChannel,
+    /// An unknown user type, contains the raw string provided by Twitch.
+    #[serde(untagged)]
+    Unknown(String),
+}
+
+/// Info about a suspicious user.
+#[derive(PartialEq, Eq, Deserialize, Serialize, Debug, Clone)]
+#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
+#[non_exhaustive]
+pub struct SuspiciousUserInfo {
+    /// The ID of the user being given the suspicious status.
+    pub user_id: types::UserId,
+    /// The user ID of the broadcaster indicating in which channel the status is being applied.
+    pub broadcaster_id: types::UserId,
+    /// The user ID of the moderator who applied the last status.
+    pub moderator_id: types::UserId,
+    /// The timestamp of the last time this user’s status was updated.
+    pub updated_at: types::Timestamp,
+    /// The type of suspicious status.
+    pub status: SuspiciousUserStatus,
+    /// An array of strings representing the type(s) of suspicious user this is.
+    pub types: Vec<SuspiciousUserType>,
 }

--- a/src/helix/endpoints/moderation/remove_suspicious_status_from_chat_user.rs
+++ b/src/helix/endpoints/moderation/remove_suspicious_status_from_chat_user.rs
@@ -1,0 +1,139 @@
+//! Remove a suspicious user status from a chatter on broadcaster’s channel.
+//! [`remove-suspicious-status-from-chat-user`](https://dev.twitch.tv/docs/api/reference#remove-suspicious-status-from-chat-user)
+//!
+//! # Accessing the endpoint
+//!
+//! ## Request: [RemoveSuspiciousStatusFromChatUserRequest]
+//!
+//! To use this endpoint, construct a [`RemoveSuspiciousStatusFromChatUserRequest`] with the [`RemoveSuspiciousStatusFromChatUserRequest::new()`] method.
+//!
+//! ```rust
+//! use twitch_api::helix::moderation::remove_suspicious_status_from_chat_user;
+//! let request = remove_suspicious_status_from_chat_user::RemoveSuspiciousStatusFromChatUserRequest::new("1234", "5678", "9876");
+//! ```
+//!
+//! ## Response: [SuspiciousUserInfo]
+//!
+//! Send the request to receive the response with [`HelixClient::req_delete()`](helix::HelixClient::req_delete).
+//!
+//! ```rust, no_run
+//! use twitch_api::helix::{self, moderation::{remove_suspicious_status_from_chat_user, SuspiciousUserInfo}};
+//! # use twitch_api::client;
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+//! # let client: helix::HelixClient<'static, client::DummyHttpClient> = helix::HelixClient::default();
+//! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
+//! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
+//! let request = remove_suspicious_status_from_chat_user::RemoveSuspiciousStatusFromChatUserRequest::new("1234", "5678", "9876");
+//! let response: SuspiciousUserInfo = client.req_delete(request, &token).await?.data;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! You can also get the [`http::Request`] with [`request.create_request(&token, &client_id)`](helix::RequestDelete::create_request)
+//! and parse the [`http::Response`] with [`RemoveSuspiciousStatusFromChatUserRequest::parse_response(None, &request.get_uri(), response)`](RemoveSuspiciousStatusFromChatUserRequest::parse_response)
+
+use super::*;
+use helix::RequestDelete;
+
+/// Query Parameters for [Remove Suspicious Status From Chat User](super::remove_suspicious_status_from_chat_user)
+///
+/// [`remove-suspicious-status-from-chat-user`](https://dev.twitch.tv/docs/api/reference#remove-suspicious-status-from-chat-user)
+#[derive(PartialEq, Eq, Deserialize, Serialize, Clone, Debug)]
+#[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
+#[must_use]
+#[non_exhaustive]
+pub struct RemoveSuspiciousStatusFromChatUserRequest<'a> {
+    /// The user ID of the broadcaster, indicating the channel where the status is being removed.
+    #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
+    #[cfg_attr(feature = "deser_borrow", serde(borrow = "'a"))]
+    pub broadcaster_id: Cow<'a, types::UserIdRef>,
+    /// The user ID of the moderator who is removing the status.
+    #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
+    #[cfg_attr(feature = "deser_borrow", serde(borrow = "'a"))]
+    pub moderator_id: Cow<'a, types::UserIdRef>,
+    /// The ID of the user having the suspicious status removed.
+    #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
+    #[cfg_attr(feature = "deser_borrow", serde(borrow = "'a"))]
+    pub user_id: Cow<'a, types::UserIdRef>,
+}
+
+impl<'a> RemoveSuspiciousStatusFromChatUserRequest<'a> {
+    /// Remove a suspicious user status from a chatter on broadcaster’s channel.
+    pub fn new(
+        broadcaster_id: impl types::IntoCow<'a, types::UserIdRef> + 'a,
+        moderator_id: impl types::IntoCow<'a, types::UserIdRef> + 'a,
+        user_id: impl types::IntoCow<'a, types::UserIdRef> + 'a,
+    ) -> Self {
+        Self {
+            broadcaster_id: broadcaster_id.into_cow(),
+            moderator_id: moderator_id.into_cow(),
+            user_id: user_id.into_cow(),
+        }
+    }
+}
+
+impl Request for RemoveSuspiciousStatusFromChatUserRequest<'_> {
+    type PaginationData = ();
+    type Response = SuspiciousUserInfo;
+
+    const PATH: &'static str = "moderation/suspicious_users";
+    #[cfg(feature = "twitch_oauth2")]
+    const SCOPE: twitch_oauth2::Validator =
+        twitch_oauth2::validator![twitch_oauth2::Scope::ModeratorManageSuspiciousUsers];
+}
+
+impl<'a> RequestDelete for RemoveSuspiciousStatusFromChatUserRequest<'a> {
+    fn parse_inner_response(
+        request: Option<Self>,
+        uri: &http::Uri,
+        response: &str,
+        status: http::StatusCode,
+    ) -> Result<helix::Response<Self, Self::Response>, helix::HelixRequestDeleteError>
+    where
+        Self: Sized,
+    {
+        helix::parse_single_return(request, uri, response, status)
+    }
+}
+
+#[cfg(test)]
+#[test]
+fn test_request() {
+    use helix::*;
+    let req = RemoveSuspiciousStatusFromChatUserRequest::new("141981764", "12826", "9876");
+
+    dbg!(req.create_request("token", "clientid").unwrap());
+
+    // From twitch docs
+    let data = br#"
+    {
+        "data": [
+            {
+                "user_id": "9876",
+                "broadcaster_id": "141981764",
+                "moderator_id": "12826",
+                "updated_at": "2025-12-01T23:08:18+00:00",
+                "status": "NO_TREATMENT",
+                "types": [
+                    "MANUALLY_ADDED"
+                ]
+            } 
+        ]
+    }
+    "#
+    .to_vec();
+
+    let http_response = http::Response::builder().body(data).unwrap();
+
+    let uri = req.get_uri().unwrap();
+    assert_eq!(
+        uri.to_string(),
+        "https://api.twitch.tv/helix/moderation/suspicious_users?broadcaster_id=141981764&moderator_id=12826&user_id=9876"
+    );
+
+    dbg!(
+        RemoveSuspiciousStatusFromChatUserRequest::parse_response(Some(req), &uri, http_response)
+            .unwrap()
+    );
+}

--- a/src/helix/mod.rs
+++ b/src/helix/mod.rs
@@ -238,7 +238,7 @@
 //!
 //! </details>
 //!
-//! <details><summary style="cursor: pointer">Moderation 🟡 23/25</summary>
+//! <details><summary style="cursor: pointer">Moderation 🟡 24/25</summary>
 //!
 //! | Endpoint | Helper | Module |
 //! |---|---|---|
@@ -265,7 +265,7 @@
 //! | [Update Shield Mode Status](https://dev.twitch.tv/docs/api/reference#update-shield-mode-status) | - | [`moderation::update_shield_mode_status`] |
 //! | [Get Shield Mode Status](https://dev.twitch.tv/docs/api/reference#get-shield-mode-status) | - | [`moderation::get_shield_mode_status`] |
 //! | [Warn Chat User](https://dev.twitch.tv/docs/api/reference#warn-chat-user) | [`HelixClient::warn_chat_user`] | [`moderation::warn_chat_user`] |
-//! | [Add Suspicious Status to Chat User](https://dev.twitch.tv/docs/api/reference#add-suspicious-status-to-chat-user) | - | - |
+//! | [Add Suspicious Status to Chat User](https://dev.twitch.tv/docs/api/reference#add-suspicious-status-to-chat-user) | [`HelixClient::add_suspicious_status_to_chat_user`] | [`moderation::add_suspicious_status_to_chat_user`] |
 //! | [Remove Suspicious Status From Chat User](https://dev.twitch.tv/docs/api/reference#remove-suspicious-status-from-chat-user) | - | - |
 //!
 //! </details>

--- a/src/helix/mod.rs
+++ b/src/helix/mod.rs
@@ -238,7 +238,7 @@
 //!
 //! </details>
 //!
-//! <details><summary style="cursor: pointer">Moderation 🟡 24/25</summary>
+//! <details><summary style="cursor: pointer">Moderation 🟢 25/25</summary>
 //!
 //! | Endpoint | Helper | Module |
 //! |---|---|---|
@@ -266,7 +266,7 @@
 //! | [Get Shield Mode Status](https://dev.twitch.tv/docs/api/reference#get-shield-mode-status) | - | [`moderation::get_shield_mode_status`] |
 //! | [Warn Chat User](https://dev.twitch.tv/docs/api/reference#warn-chat-user) | [`HelixClient::warn_chat_user`] | [`moderation::warn_chat_user`] |
 //! | [Add Suspicious Status to Chat User](https://dev.twitch.tv/docs/api/reference#add-suspicious-status-to-chat-user) | [`HelixClient::add_suspicious_status_to_chat_user`] | [`moderation::add_suspicious_status_to_chat_user`] |
-//! | [Remove Suspicious Status From Chat User](https://dev.twitch.tv/docs/api/reference#remove-suspicious-status-from-chat-user) | - | - |
+//! | [Remove Suspicious Status From Chat User](https://dev.twitch.tv/docs/api/reference#remove-suspicious-status-from-chat-user) | [`HelixClient::remove_suspicious_status_from_chat_user`] | [`moderation::remove_suspicious_status_from_chat_user`] |
 //!
 //! </details>
 //!

--- a/src/helix/request/errors.rs
+++ b/src/helix/request/errors.rs
@@ -239,6 +239,13 @@ pub enum HelixRequestDeleteError {
     },
     /// could not parse response as utf8 when calling `DELETE {2}`
     Utf8Error(hyper::body::Bytes, #[source] std::str::Utf8Error, http::Uri),
+    /// deserialization failed when processing request response calling `DELETE {2}` with response: {3} - {0:?}
+    DeserializeError(
+        String,
+        #[source] crate::DeserError,
+        http::Uri,
+        http::StatusCode,
+    ),
     /// invalid or unexpected response from twitch.
     InvalidResponse {
         /// Reason for error
@@ -319,5 +326,6 @@ impl_request_deser_error!(
     HelixRequestGetError,
     HelixRequestPatchError,
     HelixRequestPostError,
-    HelixRequestPutError
+    HelixRequestPutError,
+    HelixRequestDeleteError
 );


### PR DESCRIPTION
Adds the "add" and "remove" endpoints for suspicious status. The remove endpoint returns some data which wasn't supported in DELETE requests (or rather their errors).