### PR TITLE
Sync existing Helix endpoints and EventSub events

### DIFF
--- a/src/eventsub/channel/bits/mod.rs
+++ b/src/eventsub/channel/bits/mod.rs
@@ -14,10 +14,12 @@ pub use r#use::{ChannelBitsUseV1, ChannelBitsUseV1Payload};
 #[non_exhaustive]
 #[serde(rename_all = "snake_case")]
 pub enum BitsType {
-    /// Bits send via Cheer
+    /// Bits sent via Cheer
     Cheer,
-    /// Bits send via Power-Up
+    /// Bits sent via Power-Up
     PowerUp,
+    /// Bits sent via a custom Power-Up
+    CustomPowerUp,
 }
 
 /// Data about Power-up
@@ -31,6 +33,16 @@ pub struct BitsPowerUp {
     pub emote: Option<crate::eventsub::channel::chat::Emote>,
     /// The ID of the message effect.
     pub message_effect_id: Option<String>,
+}
+
+/// Data about a custom Power-up
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct BitsCustomPowerUp {
+    /// The title of the custom Power-up.
+    pub title: String,
+    /// The ID of the custom Power-up.
+    pub reward_id: types::RewardId,
 }
 
 /// The type of Power Up used.

--- a/src/eventsub/channel/bits/use.rs
+++ b/src/eventsub/channel/bits/use.rs
@@ -57,6 +57,8 @@ pub struct ChannelBitsUseV1Payload {
     pub type_: BitsType,
     /// Data about Power-up.
     pub power_up: Option<BitsPowerUp>,
+    /// Data about a custom Power-up.
+    pub custom_power_up: Option<BitsCustomPowerUp>,
     /// An object that contains the user message and emote information needed to recreate the message.
     pub message: Option<crate::eventsub::channel::chat::Message>,
 }

--- a/src/eventsub/channel/chat/notification.rs
+++ b/src/eventsub/channel/chat/notification.rs
@@ -74,6 +74,8 @@ pub struct ChannelChatNotificationV1Payload {
     pub source_message_id: Option<types::MsgId>,
     /// Only present when in a shared chat session. The list of chat badges for the chatter in the channel the message was sent from.
     pub source_badges: Option<Vec<Badge>>,
+    /// Whether the notification is only sent to the source channel. Is [None] if the notification is not in a shared chat session.
+    pub is_source_only: Option<bool>,
 }
 
 /// Information about the user that triggered this notification

--- a/src/eventsub/channel/chat/notification.rs
+++ b/src/eventsub/channel/chat/notification.rs
@@ -229,6 +229,9 @@ pub enum Notification {
     /// Information about the bits badge tier event.
     #[serde(with = "crate::eventsub::enum_field_as_inner")]
     BitsBadgeTier(BitsBadgeTier),
+    /// Information about the watch streak event.
+    #[serde(with = "crate::eventsub::enum_field_as_inner")]
+    WatchStreak(WatchStreak),
 
     // Shared chat notifications
     /// Information about the sub event that happened in a shared chat.
@@ -306,6 +309,10 @@ impl crate::eventsub::NamedField for CharityDonation {
 }
 impl crate::eventsub::NamedField for BitsBadgeTier {
     const NAME: &'static str = "bits_badge_tier";
+    const OPT_PREFIX: Option<&'static str> = Some("shared_chat_");
+}
+impl crate::eventsub::NamedField for WatchStreak {
+    const NAME: &'static str = "watch_streak";
     const OPT_PREFIX: Option<&'static str> = Some("shared_chat_");
 }
 
@@ -586,6 +593,17 @@ pub struct CharityDonation {
 pub struct BitsBadgeTier {
     /// The tier of the Bits badge the user just earned. For example, 100, 1000, or 10000.
     pub tier: i32,
+}
+
+/// A watch streak notification
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
+#[non_exhaustive]
+pub struct WatchStreak {
+    /// The number of consecutive broadcasts for which the user has been watching.
+    pub streak_count: u32,
+    /// The number of channel points awarded for the Watch Streak milestone.
+    pub channel_points_awarded: u32,
 }
 
 #[cfg(test)]

--- a/src/helix/client/client_ext.rs
+++ b/src/helix/client/client_ext.rs
@@ -1902,6 +1902,8 @@ impl<'client, C: crate::HttpClient + Sync + 'client> HelixClient<'client, C> {
             user_id: user_id.map(|c| c.as_cow()),
             after: None,
             first: None,
+            conduit_id: None,
+            subscription_id: None,
         };
 
         make_stream(req, token, self, |r| {

--- a/src/helix/endpoints/chat/send_chat_announcement.rs
+++ b/src/helix/endpoints/chat/send_chat_announcement.rs
@@ -73,6 +73,17 @@ pub struct SendChatAnnouncementRequest<'a> {
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[cfg_attr(feature = "deser_borrow", serde(borrow = "'a"))]
     pub moderator_id: Cow<'a, types::UserIdRef>,
+    /// Determines if the chat announcement is sent only to the source channel (defined by broadcaster_id) during a shared chat session.
+    ///
+    /// This has no effect if the announcement is not sent during a shared chat session.
+    ///
+    /// The default value when using an App Access Token is `true``.
+    /// If you prefer to send an announcement to all channels in a shared chat session, set this parameter to `false`.
+    ///
+    /// **NOTE**: This parameter can only be set when utilizing an App Access Token.
+    /// It cannot be specified when a User Access Token is used, and will instead result in an HTTP 400 error.
+    #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
+    pub for_source_only: Option<bool>,
 }
 
 impl<'a> SendChatAnnouncementRequest<'a> {
@@ -84,7 +95,14 @@ impl<'a> SendChatAnnouncementRequest<'a> {
         Self {
             broadcaster_id: broadcaster_id.into_cow(),
             moderator_id: moderator_id.into_cow(),
+            for_source_only: None,
         }
+    }
+
+    /// Set the `for_source_only` parameter.
+    pub fn for_source_only(mut self, for_source_only: bool) -> Self {
+        self.for_source_only = Some(for_source_only);
+        self
     }
 }
 

--- a/src/helix/endpoints/clips/create_clip.rs
+++ b/src/helix/endpoints/clips/create_clip.rs
@@ -40,7 +40,7 @@ use helix::RequestPost;
 /// Query Parameters for [Create Clip](super::create_clip)
 ///
 /// [`create-clip`](https://dev.twitch.tv/docs/api/reference/#create-clip)
-#[derive(PartialEq, Eq, Deserialize, Serialize, Clone, Debug)]
+#[derive(PartialEq, Deserialize, Serialize, Clone, Debug)]
 #[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
 #[must_use]
 #[non_exhaustive]
@@ -49,9 +49,15 @@ pub struct CreateClipRequest<'a> {
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[cfg_attr(feature = "deser_borrow", serde(borrow = "'a"))]
     pub broadcaster_id: Cow<'a, types::UserIdRef>,
-    /// A Boolean value that determines whether the API captures the clip at the moment the viewer requests it or after a delay. If false (default), Twitch captures the clip at the moment the viewer requests it (this is the same clip experience as the Twitch UX). If true, Twitch adds a delay before capturing the clip (this basically shifts the capture window to the right slightly).
+
+    /// The length of the clip in seconds. Possible values range from 5 to 60 inclusively with a precision of 0.1. The default is 30.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
-    pub has_delay: Option<bool>,
+    pub duration: Option<f32>,
+
+    /// The title of the clip.
+    #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
+    #[cfg_attr(feature = "deser_borrow", serde(borrow = "'a"))]
+    pub title: Option<Cow<'a, str>>,
 }
 
 impl<'a> CreateClipRequest<'a> {
@@ -59,13 +65,20 @@ impl<'a> CreateClipRequest<'a> {
     pub fn broadcaster_id(broadcaster_id: impl types::IntoCow<'a, types::UserIdRef> + 'a) -> Self {
         Self {
             broadcaster_id: broadcaster_id.into_cow(),
-            has_delay: None,
+            duration: None,
+            title: None,
         }
     }
 
-    /// Sets the has_delay parameter
-    pub const fn has_delay(mut self, has_delay: bool) -> Self {
-        self.has_delay = Some(has_delay);
+    /// Sets the `duration` parameter
+    pub fn duration(mut self, duration: f32) -> Self {
+        self.duration = Some(duration);
+        self
+    }
+
+    /// Sets the `title` parameter
+    pub fn title(mut self, title: impl Into<Cow<'a, str>>) -> Self {
+        self.title = Some(title.into());
         self
     }
 }

--- a/src/helix/endpoints/eventsub/get_eventsub_subscriptions.rs
+++ b/src/helix/endpoints/eventsub/get_eventsub_subscriptions.rs
@@ -25,6 +25,14 @@ pub struct GetEventSubSubscriptionsRequest<'a> {
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     #[cfg_attr(feature = "deser_borrow", serde(borrow = "'a"))]
     pub user_id: Option<Cow<'a, types::UserIdRef>>,
+    /// Filter subscriptions by conduit ID.
+    #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
+    #[cfg_attr(feature = "deser_borrow", serde(borrow = "'a"))]
+    pub conduit_id: Option<Cow<'a, types::ConduitIdRef>>,
+    /// Returns an array with the subscription matching the ID (as long as it is owned by the client making the request), or an empty array if there is no matching subscription.
+    #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
+    #[cfg_attr(feature = "deser_borrow", serde(borrow = "'a"))]
+    pub subscription_id: Option<Cow<'a, types::EventSubId>>,
     // FIXME: https://github.com/twitchdev/issues/issues/272
     /// Cursor for forward pagination
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]


### PR DESCRIPTION
I went through the [changelog](https://dev.twitch.tv/docs/change-log/) about 1 year and updated our types accordingly.