### PR TITLE
refactor(helix): unwrap nested enums

### DIFF
--- a/src/helix/endpoints/points/mod.rs
+++ b/src/helix/endpoints/points/mod.rs
@@ -66,9 +66,7 @@ pub use get_custom_reward_redemption::{CustomRewardRedemption, GetCustomRewardRe
 #[doc(inline)]
 pub use update_custom_reward::{UpdateCustomRewardBody, UpdateCustomRewardRequest};
 #[doc(inline)]
-pub use update_redemption_status::{
-    UpdateRedemptionStatusBody, UpdateRedemptionStatusInformation, UpdateRedemptionStatusRequest,
-};
+pub use update_redemption_status::{UpdateRedemptionStatusBody, UpdateRedemptionStatusRequest};
 /// Custom reward redemption statuses: UNFULFILLED, FULFILLED or CANCELED
 #[derive(PartialEq, Eq, Serialize, Deserialize, Copy, Clone, Debug)]
 #[non_exhaustive]

--- a/src/helix/endpoints/points/update_custom_reward.rs
+++ b/src/helix/endpoints/points/update_custom_reward.rs
@@ -28,14 +28,14 @@
 //! body.title = Some("hydrate but differently now!".into());
 //! ```
 //!
-//! ## Response: [UpdateCustomReward]
+//! ## Response: [CustomReward]
 //!
 //!
 //! Send the request to receive the response with [`HelixClient::req_patch()`](helix::HelixClient::req_patch).
 //!
 //!
 //! ```rust, no_run
-//! use twitch_api::helix::{self, points::update_custom_reward};
+//! use twitch_api::helix::{self, points::{self, update_custom_reward}};
 //! # use twitch_api::client;
 //! # #[tokio::main]
 //! # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
@@ -46,15 +46,13 @@
 //! let mut body = update_custom_reward::UpdateCustomRewardBody::default();
 //! body.cost = Some(501);
 //! body.title = Some("hydrate but differently now!".into());
-//! let response: update_custom_reward::UpdateCustomReward = client.req_patch(request, body, &token).await?.data;
+//! let response: points::CustomReward = client.req_patch(request, body, &token).await?.data;
 //! # Ok(())
 //! # }
 //! ```
 //!
 //! You can also get the [`http::Request`] with [`request.create_request(&token, &client_id)`](helix::RequestPost::create_request)
 //! and parse the [`http::Response`] with [`UpdateCustomRewardRequest::parse_response(None, &request.get_uri(), response)`](UpdateCustomRewardRequest::parse_response)
-
-use crate::helix::{parse_json, HelixRequestPatchError};
 
 use super::*;
 use helix::RequestPatch;
@@ -159,20 +157,9 @@ pub struct UpdateCustomRewardBody<'a> {
 
 impl helix::private::SealedSerialize for UpdateCustomRewardBody<'_> {}
 
-/// Return Values for [Update CustomReward](super::update_custom_reward)
-///
-/// [`update-custom-reward`](https://dev.twitch.tv/docs/api/reference#update-custom-reward)
-#[derive(PartialEq, Eq, Deserialize, Serialize, Debug, Clone)]
-#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
-#[non_exhaustive]
-pub enum UpdateCustomReward {
-    /// Reward updated
-    Success(CustomReward),
-}
-
 impl Request for UpdateCustomRewardRequest<'_> {
     type PaginationData = ();
-    type Response = UpdateCustomReward;
+    type Response = CustomReward;
 
     const PATH: &'static str = "channel_points/custom_rewards";
     #[cfg(feature = "twitch_oauth2")]
@@ -192,30 +179,7 @@ impl<'a> RequestPatch for UpdateCustomRewardRequest<'a> {
     where
         Self: Sized,
     {
-        let resp = match status {
-            http::StatusCode::OK => {
-                let resp: helix::InnerResponse<[CustomReward; 1]> = parse_json(response, true)
-                    .map_err(|e| {
-                        HelixRequestPatchError::DeserializeError(
-                            response.to_string(),
-                            e,
-                            uri.clone(),
-                            status,
-                        )
-                    })?;
-                let [data] = resp.data;
-                UpdateCustomReward::Success(data)
-            }
-            _ => {
-                return Err(helix::HelixRequestPatchError::InvalidResponse {
-                    reason: "unexpected status code",
-                    response: response.to_string(),
-                    status,
-                    uri: uri.clone(),
-                })
-            }
-        };
-        Ok(helix::Response::with_data(resp, request))
+        helix::parse_single_return(request, uri, response, status)
     }
 }
 

--- a/src/helix/endpoints/points/update_redemption_status.rs
+++ b/src/helix/endpoints/points/update_redemption_status.rs
@@ -31,7 +31,7 @@
 //! );
 //! ```
 //!
-//! ## Response: [UpdateRedemptionStatusInformation]
+//! ## Response: [CustomRewardRedemption]
 //!
 //! Send the request to receive the response with [`HelixClient::req_get()`](helix::HelixClient::req_get).
 //!
@@ -39,7 +39,7 @@
 //! use twitch_api::helix;
 //! use twitch_api::helix::points::{
 //!     CustomRewardRedemptionStatus, UpdateRedemptionStatusBody,
-//!     UpdateRedemptionStatusInformation, UpdateRedemptionStatusRequest,
+//!     CustomRewardRedemption, UpdateRedemptionStatusRequest,
 //! };
 //! # use twitch_api::client;
 //! # #[tokio::main]
@@ -54,7 +54,7 @@
 //!     "17fa2df1-ad76-4804-bfa5-a40ef63efe63",
 //! );
 //! let body = UpdateRedemptionStatusBody::status(CustomRewardRedemptionStatus::Canceled);
-//! let response: UpdateRedemptionStatusInformation =
+//! let response: CustomRewardRedemption =
 //!     client.req_patch(request, body, &token).await?.data;
 //! # Ok(())
 //! # }
@@ -62,8 +62,6 @@
 //!
 //! You can also get the [`http::Request`] with [`request.create_request(body, &token, &client_id)`](helix::RequestPatch::create_request)
 //! and parse the [`http::Response`] with [`UpdateRedemptionStatusRequest::parse_response(None, &request.get_uri(), response)`](UpdateRedemptionStatusRequest::parse_response)
-
-use crate::helix::{parse_json, HelixRequestPatchError};
 
 pub use super::CustomRewardRedemption;
 use super::*;
@@ -125,20 +123,9 @@ impl UpdateRedemptionStatusBody {
     pub const fn status(status: CustomRewardRedemptionStatus) -> Self { Self { status } }
 }
 
-/// FIXME: Returns an object.
-/// Return Values for [Update Redemption Status](super::update_redemption_status)
-///
-/// [`update-redemption-status`](https://dev.twitch.tv/docs/api/reference#update-redemption-status)
-#[derive(PartialEq, Eq, Deserialize, Serialize, Debug, Clone)]
-#[non_exhaustive]
-pub enum UpdateRedemptionStatusInformation {
-    /// 200 - OK
-    Success(CustomRewardRedemption),
-}
-
 impl Request for UpdateRedemptionStatusRequest<'_> {
     type PaginationData = ();
-    type Response = UpdateRedemptionStatusInformation;
+    type Response = CustomRewardRedemption;
 
     const PATH: &'static str = "channel_points/custom_rewards/redemptions";
     #[cfg(feature = "twitch_oauth2")]
@@ -158,30 +145,7 @@ impl RequestPatch for UpdateRedemptionStatusRequest<'_> {
     where
         Self: Sized,
     {
-        let resp = match status {
-            http::StatusCode::OK => {
-                let resp: helix::InnerResponse<[CustomRewardRedemption; 1]> =
-                    parse_json(response, true).map_err(|e| {
-                        HelixRequestPatchError::DeserializeError(
-                            response.to_string(),
-                            e,
-                            uri.clone(),
-                            status,
-                        )
-                    })?;
-                let [data] = resp.data;
-                UpdateRedemptionStatusInformation::Success(data)
-            }
-            _ => {
-                return Err(helix::HelixRequestPatchError::InvalidResponse {
-                    reason: "unexpected status code",
-                    response: response.to_string(),
-                    status,
-                    uri: uri.clone(),
-                })
-            }
-        };
-        Ok(helix::Response::with_data(resp, request))
+        helix::parse_single_return(request, uri, response, status)
     }
 }
 

--- a/src/helix/endpoints/polls/end_poll.rs
+++ b/src/helix/endpoints/polls/end_poll.rs
@@ -26,14 +26,14 @@
 //! );
 //! ```
 //!
-//! ## Response: [EndPoll]
+//! ## Response: [Poll]
 //!
 //!
 //! Send the request to receive the response with [`HelixClient::req_patch()`](helix::HelixClient::req_patch).
 //!
 //!
 //! ```rust, no_run
-//! use twitch_api::helix::{self, polls::end_poll};
+//! use twitch_api::helix::{self, polls::{self, end_poll}};
 //! # use twitch_api::client;
 //! # #[tokio::main]
 //! # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
@@ -46,7 +46,7 @@
 //!     "92af127c-7326-4483-a52b-b0da0be61c01",
 //!     end_poll::PollStatus::Terminated,
 //! );
-//! let response: end_poll::EndPoll = client.req_patch(request, body, &token).await?.data;
+//! let response: polls::Poll = client.req_patch(request, body, &token).await?.data;
 //! # Ok(())
 //! # }
 //! ```
@@ -55,8 +55,6 @@
 //! and parse the [`http::Response`] with [`EndPollRequest::parse_response(None, &request.get_uri(), response)`](EndPollRequest::parse_response)
 
 use std::marker::PhantomData;
-
-use crate::helix::{parse_json, HelixRequestPatchError};
 
 use super::*;
 use helix::RequestPatch;
@@ -118,25 +116,9 @@ impl<'a> EndPollBody<'a> {
 
 impl helix::private::SealedSerialize for EndPollBody<'_> {}
 
-/// Return Values for [Update CustomReward](super::end_poll)
-///
-/// [`end-poll`](https://dev.twitch.tv/docs/api/reference#end-poll)
-#[derive(PartialEq, Eq, Deserialize, Debug, Clone)]
-#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
-#[non_exhaustive]
-#[allow(clippy::large_enum_variant)]
-pub enum EndPoll {
-    /// Poll ended successfully.
-    Success(Poll),
-    /// Bad Request: Query/Body Parameter missing or invalid
-    MissingQuery,
-    /// Unauthenticated: Missing/invalid Token
-    AuthFailed,
-}
-
 impl Request for EndPollRequest<'_> {
     type PaginationData = ();
-    type Response = EndPoll;
+    type Response = Poll;
 
     const PATH: &'static str = "polls";
     #[cfg(feature = "twitch_oauth2")]
@@ -156,32 +138,7 @@ impl<'a> RequestPatch for EndPollRequest<'a> {
     where
         Self: Sized,
     {
-        let resp = match status {
-            http::StatusCode::OK => {
-                let resp: helix::InnerResponse<[Poll; 1]> =
-                    parse_json(response, true).map_err(|e| {
-                        HelixRequestPatchError::DeserializeError(
-                            response.to_string(),
-                            e,
-                            uri.clone(),
-                            status,
-                        )
-                    })?;
-                let [data] = resp.data;
-                EndPoll::Success(data)
-            }
-            http::StatusCode::BAD_REQUEST => EndPoll::MissingQuery,
-            http::StatusCode::UNAUTHORIZED => EndPoll::AuthFailed,
-            _ => {
-                return Err(helix::HelixRequestPatchError::InvalidResponse {
-                    reason: "unexpected status code",
-                    response: response.to_string(),
-                    status,
-                    uri: uri.clone(),
-                })
-            }
-        };
-        Ok(helix::Response::with_data(resp, request))
+        helix::parse_single_return(request, uri, response, status)
     }
 }
 

--- a/src/helix/endpoints/predictions/end_prediction.rs
+++ b/src/helix/endpoints/predictions/end_prediction.rs
@@ -26,7 +26,7 @@
 //! );
 //! ```
 //!
-//! ## Response: [EndPrediction]
+//! ## Response: [Prediction]
 //!
 //!
 //! Send the request to receive the response with [`HelixClient::req_patch()`](helix::HelixClient::req_patch).
@@ -46,7 +46,7 @@
 //!     "ed961efd-8a3f-4cf5-a9d0-e616c590cd2a",
 //!     twitch_types::PredictionStatus::Resolved
 //! );
-//! let response: end_prediction::EndPrediction = client.req_patch(request, body, &token).await?.data;
+//! let response: predictions::Prediction = client.req_patch(request, body, &token).await?.data;
 //! # Ok(())
 //! # }
 //! ```
@@ -55,8 +55,6 @@
 //! and parse the [`http::Response`] with [`EndPredictionRequest::parse_response(None, &request.get_uri(), response)`](EndPredictionRequest::parse_response)
 
 use std::marker::PhantomData;
-
-use crate::helix::{parse_json, HelixRequestPatchError};
 
 use super::*;
 use helix::RequestPatch;
@@ -133,25 +131,9 @@ impl<'a> EndPredictionBody<'a> {
 
 impl helix::private::SealedSerialize for EndPredictionBody<'_> {}
 
-/// Return Values for [Update CustomReward](super::end_prediction)
-///
-/// [`end-prediction`](https://dev.twitch.tv/docs/api/reference#end-prediction)
-#[derive(PartialEq, Eq, Deserialize, Debug, Clone)]
-#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
-#[non_exhaustive]
-#[allow(clippy::large_enum_variant)]
-pub enum EndPrediction {
-    /// Prediction ended successfully.
-    Success(Prediction),
-    /// Bad Request: Query/Body Parameter missing or invalid
-    MissingQuery,
-    /// Unauthenticated: Missing/invalid Token
-    AuthFailed,
-}
-
 impl Request for EndPredictionRequest<'_> {
     type PaginationData = ();
-    type Response = EndPrediction;
+    type Response = Prediction;
 
     const PATH: &'static str = "predictions";
     #[cfg(feature = "twitch_oauth2")]
@@ -171,32 +153,7 @@ impl<'a> RequestPatch for EndPredictionRequest<'a> {
     where
         Self: Sized,
     {
-        let resp = match status {
-            http::StatusCode::OK => {
-                let resp: helix::InnerResponse<[Prediction; 1]> = parse_json(response, true)
-                    .map_err(|e| {
-                        HelixRequestPatchError::DeserializeError(
-                            response.to_string(),
-                            e,
-                            uri.clone(),
-                            status,
-                        )
-                    })?;
-                let [data] = resp.data;
-                EndPrediction::Success(data)
-            }
-            http::StatusCode::BAD_REQUEST => EndPrediction::MissingQuery,
-            http::StatusCode::UNAUTHORIZED => EndPrediction::AuthFailed,
-            _ => {
-                return Err(helix::HelixRequestPatchError::InvalidResponse {
-                    reason: "unexpected status code",
-                    response: response.to_string(),
-                    status,
-                    uri: uri.clone(),
-                })
-            }
-        };
-        Ok(helix::Response::with_data(resp, request))
+        helix::parse_single_return(request, uri, response, status)
     }
 }
 


### PR DESCRIPTION
Some endpoints returned an enum with `Success(ActualResponse)`. This unwraps the enum and changes the return value to `ActualResponse`.

Closes #508.