### PR TITLE
chore: Address (some) clippy lints

### DIFF
--- a/examples/eventsub/src/twitch.rs
+++ b/examples/eventsub/src/twitch.rs
@@ -257,8 +257,8 @@ pub async fn refresher(
 }
 
 #[tracing::instrument(skip(client, token))]
-pub async fn is_live<'a>(
-    config: &'a Config,
+pub async fn is_live(
+    config: &Config,
     client: &HelixClient<'_, reqwest::Client>,
     token: &AppAccessToken,
 ) -> eyre::Result<LiveStatus> {

--- a/examples/eventsub_websocket/src/util.rs
+++ b/examples/eventsub_websocket/src/util.rs
@@ -56,8 +56,8 @@ fn install_tracing() {
 
 /// Create a new [UserToken] from an [AccessToken]
 #[tracing::instrument(skip(client, token))]
-pub async fn make_token<'a>(
-    client: &'a impl twitch_oauth2::client::Client,
+pub async fn make_token(
+    client: &impl twitch_oauth2::client::Client,
     token: impl Into<twitch_oauth2::AccessToken>,
 ) -> Result<UserToken, eyre::Report> {
     UserToken::from_token(client, token.into())

--- a/src/helix/client/client_ext.rs
+++ b/src/helix/client/client_ext.rs
@@ -1554,7 +1554,7 @@ impl<'client, C: crate::HttpClient + Sync + 'client> HelixClient<'client, C> {
     /// Gets a list of all extensions (both active and inactive) that the broadcaster has installed.
     ///
     /// The user ID in the access token identifies the broadcaster.
-    pub async fn get_user_extensions<'b, T>(
+    pub async fn get_user_extensions<T>(
         &'client self,
         token: &T,
     ) -> Result<Vec<helix::users::Extension>, ClientError<C>>
@@ -1569,7 +1569,7 @@ impl<'client, C: crate::HttpClient + Sync + 'client> HelixClient<'client, C> {
     /// Gets the active extensions that the broadcaster has installed for each configuration.
     ///
     /// The user ID in the access token identifies the broadcaster.
-    pub async fn get_user_active_extensions<'b, T>(
+    pub async fn get_user_active_extensions<T>(
         &'client self,
         token: &T,
     ) -> Result<helix::users::ExtensionConfiguration, ClientError<C>>
@@ -1803,7 +1803,7 @@ impl<'client, C: crate::HttpClient + Sync + 'client> HelixClient<'client, C> {
     ///     .await?;
     /// # Ok(()) }
     /// ```
-    pub async fn get_content_classification_labels<'b, T>(
+    pub async fn get_content_classification_labels<T>(
         &'client self,
         token: &'client T,
     ) -> Result<Vec<helix::ccls::ContentClassificationLabel>, ClientError<C>>

--- a/src/pubsub/mod.rs
+++ b/src/pubsub/mod.rs
@@ -326,7 +326,7 @@ pub struct TwitchResponse {
 
 impl TwitchResponse {
     /// Whether response indicates success or not
-    pub fn is_successful(&self) -> bool { self.error.as_ref().map_or(true, |s| s.is_empty()) }
+    pub fn is_successful(&self) -> bool { self.error.as_ref().is_none_or(|s| s.is_empty()) }
 }
 
 // FIXME: Add example

--- a/xtask/src/collect_endpoints/mod.rs
+++ b/xtask/src/collect_endpoints/mod.rs
@@ -42,7 +42,7 @@ pub fn run(sh: &Shell, build_json_docs: bool, all_features: &str) -> Result<()> 
     }
     let json = sh.read_file("target/doc/twitch_api.json")?;
     let rustdoc = serde_json::from_str(&json)?;
-    let (mut helix_rustdoc, eventsub_rustdoc) = rustdoc::parse(&rustdoc)?;
+    let (helix_rustdoc, eventsub_rustdoc) = rustdoc::parse(&rustdoc)?;
 
     let (helix, eventsub) = (
         helix_h.join().expect("failed to join helix thread")?,
@@ -52,7 +52,7 @@ pub fn run(sh: &Shell, build_json_docs: bool, all_features: &str) -> Result<()> 
     std::thread::scope(|s| -> Result<()> {
         let h1 = s.spawn(|| -> Result<()> {
             let overview =
-                helix::make_overview(&Url::parse(HELIX_URL).unwrap(), &helix, &mut helix_rustdoc)?;
+                helix::make_overview(&Url::parse(HELIX_URL).unwrap(), &helix, &helix_rustdoc)?;
             paste_in_file(HELIX_SOURCE_FILE, overview.0)?;
             for (module, doc) in overview.1 {
                 let path = format!("{}{}/mod.rs", HELIX_ENDPOINTS_FOLDER, module);
@@ -117,12 +117,12 @@ pub fn levenshtein(src: &str, tar: &str) -> usize {
     // initialize the matrix
     let mut matrix: Vec<Vec<usize>> = vec![vec![0; tar_len + 1]; src_len + 1];
 
-    for i in 1..(src_len + 1) {
-        matrix[i][0] = i;
+    for (i, row) in matrix.iter_mut().enumerate().skip(1) {
+        row[0] = i;
     }
 
-    for i in 1..(tar_len + 1) {
-        matrix[0][i] = i;
+    for (i, v) in matrix[0].iter_mut().enumerate().skip(1) {
+        *v = i;
     }
 
     // apply edit operations


### PR DESCRIPTION
This fixes some of the warnings clippy gave us. There are two ones left.

1. In `ureq_client.rs`:
   ```
   warning: calling .bytes() is very inefficient when data is not in memory
   --> src\client\ureq_impl.rs:86:19
      |
   86 |               match response
      |  ___________________^
   87 | |                 .into_reader()
   88 | |                 .take(10_000_000)
   89 | |                 .bytes()
      | |________________________^
      |
      = help: consider using `BufReader`
      = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unbuffered_bytes
      = note: `#[warn(clippy::unbuffered_bytes)]` on by default
   ```
   Not sure if the data is in memory here, but I'd expect it to be at least buffered.
2. In `helix/request.rs`: "the `Err`-variant returned from this function is very large" For every function returning a `Result<..., HelixRequest*Error>`. We could box these, not sure if we should.