### PR TITLE
Add hypetrain v2 events

### DIFF
--- a/src/common/hypetrain.rs
+++ b/src/common/hypetrain.rs
@@ -1,0 +1,49 @@
+//! Common types for hype trains.
+
+use crate::types;
+use serde_derive::{Deserialize, Serialize};
+
+/// A broadcaster participating in a hype train.
+#[derive(PartialEq, Eq, Deserialize, Serialize, Debug, Clone)]
+#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
+#[non_exhaustive]
+pub struct SharedTrainParticipant {
+    /// The broadcaster ID.
+    pub broadcaster_user_id: types::UserId,
+    /// The broadcaster login.
+    pub broadcaster_user_login: types::UserName,
+    /// The broadcaster display name.
+    pub broadcaster_user_name: types::DisplayName,
+}
+
+/// Type of Hype Train event
+#[derive(PartialEq, Eq, Deserialize, Serialize, Debug, Clone)]
+#[non_exhaustive]
+#[serde(rename_all = "snake_case")]
+pub enum HypeTrainType {
+    /// A treasure train.
+    Treasure,
+    /// A golden Kappa train.
+    GoldenKappa,
+    /// A regular train.
+    Regular,
+    /// An unknown hype train type, contains the raw string provided by Twitch.
+    #[serde(untagged)]
+    Unknown(String),
+}
+
+/// Type of Hype Train event
+#[derive(PartialEq, Eq, Deserialize, Serialize, Debug, Clone)]
+#[non_exhaustive]
+#[serde(rename_all = "snake_case")]
+pub enum HypeTrainContributionType {
+    /// Cheering with bits
+    Bits,
+    /// Subscription activity like subscribing or gifting subscriptions.
+    Subscription,
+    /// Covers other contribution methods not listed.
+    Other,
+    /// An unknown contribution type, contains the raw string provided by Twitch.
+    #[serde(untagged)]
+    Unknown(String),
+}

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -1,3 +1,4 @@
 //! Common types between Helix and EventSub.
 
 pub mod chat;
+pub mod hypetrain;

--- a/src/eventsub/channel/hypetrain/begin.rs
+++ b/src/eventsub/channel/hypetrain/begin.rs
@@ -108,3 +108,128 @@ fn parse_payload() {
     let val = dbg!(crate::eventsub::Event::parse(payload).unwrap());
     crate::tests::roundtrip(&val)
 }
+
+/// [`channel.hype_train.begin`](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#channelhype_trainbegin): a hype train begins on the specified channel.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
+#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
+#[non_exhaustive]
+pub struct ChannelHypeTrainBeginV2 {
+    // FIXME: Twitch docs say "want to hype train"
+    /// The broadcaster user ID for the channel you want hype train begin notifications for.
+    #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
+    pub broadcaster_user_id: types::UserId,
+}
+
+impl ChannelHypeTrainBeginV2 {
+    /// The broadcaster user ID for the channel you want hype train begin notifications for.
+    pub fn broadcaster_user_id(broadcaster_user_id: impl Into<types::UserId>) -> Self {
+        Self {
+            broadcaster_user_id: broadcaster_user_id.into(),
+        }
+    }
+}
+
+impl EventSubscription for ChannelHypeTrainBeginV2 {
+    type Payload = ChannelHypeTrainBeginV2Payload;
+
+    const EVENT_TYPE: EventType = EventType::ChannelHypeTrainBegin;
+    #[cfg(feature = "twitch_oauth2")]
+    const SCOPE: twitch_oauth2::Validator =
+        twitch_oauth2::validator![twitch_oauth2::Scope::ChannelReadHypeTrain];
+    const VERSION: &'static str = "2";
+}
+
+/// [`channel.hype_train.begin`](ChannelHypeTrainBeginV2) response payload.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
+#[non_exhaustive]
+pub struct ChannelHypeTrainBeginV2Payload {
+    /// The Hype Train ID.
+    pub id: types::HypeTrainId,
+    /// The requested broadcaster ID.
+    pub broadcaster_user_id: types::UserId,
+    /// The requested broadcaster login.
+    pub broadcaster_user_login: types::UserName,
+    /// The requested broadcaster display name.
+    pub broadcaster_user_name: types::DisplayName,
+    /// Total points contributed to the hype train.
+    pub total: i64,
+    /// The number of points contributed to the hype train at the current level.
+    pub progress: i64,
+    /// The number of points required to reach the next level.
+    pub goal: i64,
+    // FIXME: Contains a maximum of two user objects
+    /// The contributors with the most points contributed.
+    pub top_contributions: Vec<Contribution>,
+    /// The starting level of the Hype Train.
+    pub level: i64,
+    /// The all-time high level this type of Hype Train has reached for this broadcaster.
+    pub all_time_high_level: i64,
+    /// The all-time high total this type of Hype Train has reached for this broadcaster.
+    pub all_time_high_total: i64,
+    /// Optional. Non-null for a shared Hype Train. Contains the list of broadcasters in the shared Hype Train.
+    pub shared_train_participants: Option<Vec<SharedTrainParticipant>>,
+    /// The timestamp at which the hype train started.
+    pub started_at: types::Timestamp,
+    /// The time at which the hype train expires. The expiration is extended when the hype train reaches a new level.
+    pub expires_at: types::Timestamp,
+    /// The type of the hype train
+    #[serde(rename = "type")]
+    pub type_: HypeTrainType,
+    /// Indicates if the Hype Train is shared. When true, shared_train_participants will contain the list of broadcasters the train is shared with.
+    pub is_shared_train: bool,
+}
+
+#[cfg(test)]
+#[test]
+fn parse_payload_v2() {
+    let payload = r##"
+    {
+        "subscription": {
+            "id": "f1c2a387-161a-49f9-a165-0f21d7a4e1c4",
+            "type": "channel.hype_train.begin",
+            "version": "2",
+            "status": "enabled",
+            "cost": 0,
+            "condition": {
+                "broadcaster_user_id": "1337"
+            },
+            "transport": {
+                "method": "webhook",
+                "callback": "https://example.com/webhooks/callback"
+            },
+            "created_at": "2019-11-16T10:11:12.634234626Z"
+        },
+        "event": {
+            "id": "1b0AsbInCHZW2SQFQkCzqN07Ib2",
+            "broadcaster_user_id": "1337",
+            "broadcaster_user_login": "cool_user",
+            "broadcaster_user_name": "Cool_User",
+            "total": 137,
+            "progress": 137,
+            "goal": 500,
+            "top_contributions": [
+                {
+                    "user_id": "123",
+                    "user_login": "pogchamp",
+                    "user_name": "PogChamp",
+                    "type": "bits",
+                    "total": 50
+                }
+            ],
+            "shared_train_participants": null,
+            "level": 1,
+            "started_at": "2020-07-15T17:16:03.17106713Z",
+            "expires_at": "2020-07-15T17:16:11.17106713Z",
+            "is_shared_train": false,
+            "type": "regular",
+            "all_time_high_level": 4,
+            "all_time_high_total": 2845
+        }
+    }
+    "##;
+
+    let val = dbg!(crate::eventsub::Event::parse(payload).unwrap());
+    crate::tests::roundtrip(&val)
+}

--- a/src/eventsub/channel/hypetrain/end.rs
+++ b/src/eventsub/channel/hypetrain/end.rs
@@ -101,3 +101,118 @@ fn parse_payload() {
     let val = dbg!(crate::eventsub::Event::parse(payload).unwrap());
     crate::tests::roundtrip(&val)
 }
+
+/// [`channel.hype_train.end`](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#channelhype_trainend): a hype train ends on the specified channel.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
+#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
+#[non_exhaustive]
+pub struct ChannelHypeTrainEndV2 {
+    // FIXME: Twitch docs say "want to hype train"
+    /// The broadcaster user ID for the channel you want hype train end notifications for.
+    #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
+    pub broadcaster_user_id: types::UserId,
+}
+
+impl ChannelHypeTrainEndV2 {
+    /// The broadcaster user ID for the channel you want hype train end notifications for.
+    pub fn broadcaster_user_id(broadcaster_user_id: impl Into<types::UserId>) -> Self {
+        Self {
+            broadcaster_user_id: broadcaster_user_id.into(),
+        }
+    }
+}
+
+impl EventSubscription for ChannelHypeTrainEndV2 {
+    type Payload = ChannelHypeTrainEndV2Payload;
+
+    const EVENT_TYPE: EventType = EventType::ChannelHypeTrainEnd;
+    #[cfg(feature = "twitch_oauth2")]
+    const SCOPE: twitch_oauth2::Validator =
+        twitch_oauth2::validator![twitch_oauth2::Scope::ChannelReadHypeTrain];
+    const VERSION: &'static str = "2";
+}
+
+/// [`channel.hype_train.end`](ChannelHypeTrainEndV2) response payload.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
+#[non_exhaustive]
+pub struct ChannelHypeTrainEndV2Payload {
+    /// The Hype Train ID.
+    pub id: types::HypeTrainId,
+    /// The requested broadcaster ID.
+    pub broadcaster_user_id: types::UserId,
+    /// The requested broadcaster login.
+    pub broadcaster_user_login: types::UserName,
+    /// The requested broadcaster display name.
+    pub broadcaster_user_name: types::DisplayName,
+    /// Total points contributed to the hype train.
+    pub total: i64,
+    /// The contributors with the most points contributed.
+    pub top_contributions: Vec<Contribution>,
+    /// Current level of hype train event.
+    pub level: i64,
+    /// Optional. Non-null for a shared Hype Train. Contains the list of broadcasters in the shared Hype Train.
+    pub shared_train_participants: Option<Vec<SharedTrainParticipant>>,
+    /// The timestamp at which the hype train started.
+    pub started_at: types::Timestamp,
+    /// The timestamp at which the hype train cooldown ends so that the next hype train can start.
+    pub cooldown_ends_at: types::Timestamp,
+    /// The timestamp at which the hype train ended.
+    pub ended_at: types::Timestamp,
+    /// The type of the Hype Train
+    #[serde(rename = "type")]
+    pub type_: HypeTrainType,
+    /// Indicates if the Hype Train is shared. When true, shared_train_participants will contain the list of broadcasters the train is shared with.
+    pub is_shared_train: bool,
+}
+
+#[cfg(test)]
+#[test]
+fn parse_payload_v2() {
+    let payload = r##"
+    {
+        "subscription": {
+            "id": "f1c2a387-161a-49f9-a165-0f21d7a4e1c4",
+            "type": "channel.hype_train.end",
+            "version": "2",
+            "status": "enabled",
+            "cost": 0,
+            "condition": {
+                "broadcaster_user_id": "1337"
+            },
+            "transport": {
+                "method": "webhook",
+                "callback": "https://example.com/webhooks/callback"
+            },
+            "created_at": "2019-11-16T10:11:12.634234626Z"
+        },
+        "event": {
+            "id": "1b0AsbInCHZW2SQFQkCzqN07Ib2",
+            "broadcaster_user_id": "1337",
+            "broadcaster_user_login": "cool_user",
+            "broadcaster_user_name": "Cool_User",
+            "total": 137,
+            "top_contributions": [
+                {
+                    "user_id": "123",
+                    "user_login": "pogchamp",
+                    "user_name": "PogChamp",
+                    "type": "bits",
+                    "total": 50
+                }
+            ],
+            "shared_train_participants": null,
+            "level": 1,
+            "started_at": "2020-07-15T17:16:03.17106713Z",
+            "ended_at": "2020-07-15T17:16:11.17106713Z",
+            "cooldown_ends_at": "2020-07-16T17:16:11.17106713Z",
+            "is_shared_train": false,
+            "type": "regular"
+        }
+    }
+    "##;
+
+    let val = dbg!(crate::eventsub::Event::parse(payload).unwrap());
+    crate::tests::roundtrip(&val)
+}

--- a/src/eventsub/channel/hypetrain/mod.rs
+++ b/src/eventsub/channel/hypetrain/mod.rs
@@ -1,6 +1,7 @@
 #![doc(alias = "channel.hype_train")]
 //! A hype train has started, progressed or ended.
 use super::{EventSubscription, EventType};
+use crate::common::hypetrain::{HypeTrainType, SharedTrainParticipant};
 use crate::types;
 use serde_derive::{Deserialize, Serialize};
 
@@ -9,25 +10,24 @@ pub mod end;
 pub mod progress;
 
 #[doc(inline)]
-pub use begin::{ChannelHypeTrainBeginV1, ChannelHypeTrainBeginV1Payload};
+pub use begin::{
+    ChannelHypeTrainBeginV1, ChannelHypeTrainBeginV1Payload, ChannelHypeTrainBeginV2,
+    ChannelHypeTrainBeginV2Payload,
+};
 #[doc(inline)]
-pub use end::{ChannelHypeTrainEndV1, ChannelHypeTrainEndV1Payload};
+pub use end::{
+    ChannelHypeTrainEndV1, ChannelHypeTrainEndV1Payload, ChannelHypeTrainEndV2,
+    ChannelHypeTrainEndV2Payload,
+};
 #[doc(inline)]
-pub use progress::{ChannelHypeTrainProgressV1, ChannelHypeTrainProgressV1Payload};
+pub use progress::{
+    ChannelHypeTrainProgressV1, ChannelHypeTrainProgressV1Payload, ChannelHypeTrainProgressV2,
+    ChannelHypeTrainProgressV2Payload,
+};
 
-// FIXME: Is this always the same as helix::endpoints::hypetrain::ContributionType?
-/// Type of contribution
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[non_exhaustive]
-#[serde(rename_all = "lowercase")]
-pub enum ContributionType {
-    /// Bits
-    Bits,
-    /// Channel Subscriptions. Either gifted or not.
-    Subscription,
-    /// Covers other contribution methods not listed.
-    Other,
-}
+// Re-exported from common for backwards compatability
+#[doc(inline)]
+pub use crate::common::hypetrain::HypeTrainContributionType as ContributionType;
 
 /// A contribution to hype train
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/eventsub/channel/hypetrain/progress.rs
+++ b/src/eventsub/channel/hypetrain/progress.rs
@@ -108,3 +108,122 @@ fn parse_payload() {
     let val = dbg!(crate::eventsub::Event::parse(payload).unwrap());
     crate::tests::roundtrip(&val)
 }
+
+/// [`channel.hype_train.progress`](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#channelhype_trainprogress): a hype train makes progress on the specified channel.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
+#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
+#[non_exhaustive]
+pub struct ChannelHypeTrainProgressV2 {
+    // FIXME: Twitch docs say "want to hype train"
+    /// The broadcaster user ID for the channel you want hype train progress notifications for.
+    #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
+    pub broadcaster_user_id: types::UserId,
+}
+
+impl ChannelHypeTrainProgressV2 {
+    /// The broadcaster user ID for the channel you want hype train progress notifications for.
+    pub fn broadcaster_user_id(broadcaster_user_id: impl Into<types::UserId>) -> Self {
+        Self {
+            broadcaster_user_id: broadcaster_user_id.into(),
+        }
+    }
+}
+
+impl EventSubscription for ChannelHypeTrainProgressV2 {
+    type Payload = ChannelHypeTrainProgressV2Payload;
+
+    const EVENT_TYPE: EventType = EventType::ChannelHypeTrainProgress;
+    #[cfg(feature = "twitch_oauth2")]
+    const SCOPE: twitch_oauth2::Validator =
+        twitch_oauth2::validator![twitch_oauth2::Scope::ChannelReadHypeTrain];
+    const VERSION: &'static str = "2";
+}
+
+/// [`channel.hype_train.progress`](ChannelHypeTrainProgressV2) response payload.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
+#[non_exhaustive]
+pub struct ChannelHypeTrainProgressV2Payload {
+    /// The Hype Train ID.
+    pub id: types::HypeTrainId,
+    /// The requested broadcaster ID.
+    pub broadcaster_user_id: types::UserId,
+    /// The requested broadcaster login.
+    pub broadcaster_user_login: types::UserName,
+    /// The requested broadcaster display name.
+    pub broadcaster_user_name: types::DisplayName,
+    /// Total points contributed to the hype train.
+    pub total: i64,
+    /// The number of points contributed to the hype train at the current level.
+    pub progress: i64,
+    /// The number of points required to reach the next level.
+    pub goal: i64,
+    /// // FIXME: Contains a maximum of two user objects
+    /// The contributors with the most points contributed.
+    pub top_contributions: Vec<Contribution>,
+    /// Current level of hype train event.    
+    pub level: i64,
+    /// Optional. Non-null for a shared Hype Train. Contains the list of broadcasters in the shared Hype Train.
+    pub shared_train_participants: Option<Vec<SharedTrainParticipant>>,
+    /// The timestamp at which the hype train started.
+    pub started_at: types::Timestamp,
+    /// The time at which the hype train expires. The expiration is extended when the hype train reaches a new level.
+    pub expires_at: types::Timestamp,
+    /// The type of the Hype Train
+    #[serde(rename = "type")]
+    pub type_: HypeTrainType,
+    /// ndicates if the Hype Train is shared. When true, shared_train_participants will contain the list of broadcasters the train is shared with.
+    pub is_shared_train: bool,
+}
+
+#[cfg(test)]
+#[test]
+fn parse_payload_v2() {
+    let payload = r##"
+    {
+        "subscription": {
+            "id": "f1c2a387-161a-49f9-a165-0f21d7a4e1c4",
+            "type": "channel.hype_train.progress",
+            "version": "2",
+            "status": "enabled",
+            "cost": 0,
+            "condition": {
+                "broadcaster_user_id": "1337"
+            },
+            "transport": {
+                "method": "webhook",
+                "callback": "https://example.com/webhooks/callback"
+            },
+            "created_at": "2019-11-16T10:11:12.634234626Z"
+        },
+        "event": {
+            "id": "1b0AsbInCHZW2SQFQkCzqN07Ib2",
+            "broadcaster_user_id": "1337",
+            "broadcaster_user_login": "cool_user",
+            "broadcaster_user_name": "Cool_User",
+            "total": 137,
+            "progress": 137,
+            "goal": 500,
+            "top_contributions": [
+                {
+                    "user_id": "123",
+                    "user_login": "pogchamp",
+                    "user_name": "PogChamp",
+                    "type": "bits",
+                    "total": 50
+                }
+            ],
+            "shared_train_participants": null,
+            "level": 1,
+            "started_at": "2020-07-15T17:16:03.17106713Z",
+            "expires_at": "2020-07-15T17:16:11.17106713Z",
+            "is_shared_train": false,
+            "type": "regular"
+        }
+    }
+    "##;
+
+    let val = dbg!(crate::eventsub::Event::parse(payload).unwrap());
+    crate::tests::roundtrip(&val)
+}

--- a/src/eventsub/channel/mod.rs
+++ b/src/eventsub/channel/mod.rs
@@ -130,11 +130,20 @@ pub use guest_star_settings::{
     ChannelGuestStarSettingsUpdateBeta, ChannelGuestStarSettingsUpdateBetaPayload,
 };
 #[doc(inline)]
-pub use hypetrain::{ChannelHypeTrainBeginV1, ChannelHypeTrainBeginV1Payload};
+pub use hypetrain::{
+    ChannelHypeTrainBeginV1, ChannelHypeTrainBeginV1Payload, ChannelHypeTrainBeginV2,
+    ChannelHypeTrainBeginV2Payload,
+};
 #[doc(inline)]
-pub use hypetrain::{ChannelHypeTrainEndV1, ChannelHypeTrainEndV1Payload};
+pub use hypetrain::{
+    ChannelHypeTrainEndV1, ChannelHypeTrainEndV1Payload, ChannelHypeTrainEndV2,
+    ChannelHypeTrainEndV2Payload,
+};
 #[doc(inline)]
-pub use hypetrain::{ChannelHypeTrainProgressV1, ChannelHypeTrainProgressV1Payload};
+pub use hypetrain::{
+    ChannelHypeTrainProgressV1, ChannelHypeTrainProgressV1Payload, ChannelHypeTrainProgressV2,
+    ChannelHypeTrainProgressV2Payload,
+};
 #[doc(inline)]
 pub use moderate::{ChannelModerateV1, ChannelModerateV1Payload};
 #[doc(inline)]

--- a/src/eventsub/event.rs
+++ b/src/eventsub/event.rs
@@ -47,8 +47,11 @@ macro_rules! fill_events {
             #[cfg(feature = "beta")]
             channel::ChannelGuestStarSettingsUpdateBeta;
             channel::ChannelHypeTrainBeginV1;
+            channel::ChannelHypeTrainBeginV2;
             channel::ChannelHypeTrainEndV1;
+            channel::ChannelHypeTrainEndV2;
             channel::ChannelHypeTrainProgressV1;
+            channel::ChannelHypeTrainProgressV2;
             channel::ChannelModerateV1;
             channel::ChannelModerateV2;
             channel::ChannelModeratorAddV1;
@@ -485,11 +488,20 @@ pub enum Event {
     #[cfg(feature = "beta")]
     ChannelGuestStarGuestUpdateBeta(Payload<channel::ChannelGuestStarGuestUpdateBeta>),
     /// Channel Hype Train Begin V1 Event
+    #[deprecated(note = "use `Event::ChannelHypeTrainBeginV2` instead")]
     ChannelHypeTrainBeginV1(Payload<channel::ChannelHypeTrainBeginV1>),
+    /// Channel Hype Train Begin V2 Event
+    ChannelHypeTrainBeginV2(Payload<channel::ChannelHypeTrainBeginV2>),
     /// Channel Hype Train Progress V1 Event
+    #[deprecated(note = "use `Event::ChannelHypeTrainProgressV2` instead")]
     ChannelHypeTrainProgressV1(Payload<channel::ChannelHypeTrainProgressV1>),
+    /// Channel Hype Train Progress V2 Event
+    ChannelHypeTrainProgressV2(Payload<channel::ChannelHypeTrainProgressV2>),
     /// Channel Hype Train End V1 Event
+    #[deprecated(note = "use `Event::ChannelHypeTrainEndV2` instead")]
     ChannelHypeTrainEndV1(Payload<channel::ChannelHypeTrainEndV1>),
+    /// Channel Hype Train End V2 Event
+    ChannelHypeTrainEndV2(Payload<channel::ChannelHypeTrainEndV2>),
     /// Channel Moderate V1 Event
     ChannelModerateV1(Payload<channel::ChannelModerateV1>),
     /// Channel Moderate V2 Event

--- a/src/eventsub/mod.rs
+++ b/src/eventsub/mod.rs
@@ -92,7 +92,7 @@
 //!
 //! </details>
 //!
-//! <details><summary style="cursor: pointer"><code style="color: var(--link-color)">channel.*</code> 🟡 63/68</summary>
+//! <details><summary style="cursor: pointer"><code style="color: var(--link-color)">channel.*</code> 🟡 66/68</summary>
 //!
 //! | Name | Subscription<br>Payload |
 //! |---|:---|
@@ -128,9 +128,9 @@
 //! | [`channel.guest_star_session.begin`](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#channelguest_star_sessionbegin) (beta) | [ChannelGuestStarSessionBeginBeta](channel::ChannelGuestStarSessionBeginBeta)<br>[ChannelGuestStarSessionBeginBetaPayload](channel::ChannelGuestStarSessionBeginBetaPayload) |
 //! | [`channel.guest_star_session.end`](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#channelguest_star_sessionend) (beta) | [ChannelGuestStarSessionEndBeta](channel::ChannelGuestStarSessionEndBeta)<br>[ChannelGuestStarSessionEndBetaPayload](channel::ChannelGuestStarSessionEndBetaPayload) |
 //! | [`channel.guest_star_settings.update`](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#channelguest_star_settingsupdate) (beta) | [ChannelGuestStarSettingsUpdateBeta](channel::ChannelGuestStarSettingsUpdateBeta)<br>[ChannelGuestStarSettingsUpdateBetaPayload](channel::ChannelGuestStarSettingsUpdateBetaPayload) |
-//! | [`channel.hype_train.begin`](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#channelhype_trainbegin) (v2) | -<br>- |
-//! | [`channel.hype_train.end`](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#channelhype_trainend) (v2) | -<br>- |
-//! | [`channel.hype_train.progress`](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#channelhype_trainprogress) (v2) | -<br>- |
+//! | [`channel.hype_train.begin`](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#channelhype_trainbegin) (v2) | [ChannelHypeTrainBeginV2](channel::ChannelHypeTrainBeginV2)<br>[ChannelHypeTrainBeginV2Payload](channel::ChannelHypeTrainBeginV2Payload) |
+//! | [`channel.hype_train.end`](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#channelhype_trainend) (v2) | [ChannelHypeTrainEndV2](channel::ChannelHypeTrainEndV2)<br>[ChannelHypeTrainEndV2Payload](channel::ChannelHypeTrainEndV2Payload) |
+//! | [`channel.hype_train.progress`](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#channelhype_trainprogress) (v2) | [ChannelHypeTrainProgressV2](channel::ChannelHypeTrainProgressV2)<br>[ChannelHypeTrainProgressV2Payload](channel::ChannelHypeTrainProgressV2Payload) |
 //! | [`channel.moderate`](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#channelmoderate) (v1) | [ChannelModerateV1](channel::ChannelModerateV1)<br>[ChannelModerateV1Payload](channel::ChannelModerateV1Payload) |
 //! | [`channel.moderate`](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#channelmoderate-v2) (v2) | [ChannelModerateV2](channel::ChannelModerateV2)<br>[ChannelModerateV2Payload](channel::ChannelModerateV2Payload) |
 //! | [`channel.moderator.add`](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#channelmoderatoradd) (v1) | [ChannelModeratorAddV1](channel::ChannelModeratorAddV1)<br>[ChannelModeratorAddV1Payload](channel::ChannelModeratorAddV1Payload) |

--- a/src/helix/endpoints/hypetrain/get_hype_train_status.rs
+++ b/src/helix/endpoints/hypetrain/get_hype_train_status.rs
@@ -36,6 +36,12 @@
 use super::*;
 use helix::RequestGet;
 
+// Re-exported from common for backwards compatability
+#[doc(inline)]
+pub use crate::common::hypetrain::{
+    HypeTrainContributionType, HypeTrainType, SharedTrainParticipant,
+};
+
 /// Query Parameters for [Get Hype Train Status](super::get_hype_train_status)
 ///
 /// [`get-hype-train-status`](https://dev.twitch.tv/docs/api/reference#get-hype-train-status)
@@ -132,19 +138,6 @@ pub struct TopContribution {
     pub total: u64,
 }
 
-/// A broadcaster participating in a hype train.
-#[derive(PartialEq, Eq, Deserialize, Serialize, Debug, Clone)]
-#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
-#[non_exhaustive]
-pub struct SharedTrainParticipant {
-    /// The broadcaster ID.
-    pub broadcaster_user_id: types::UserId,
-    /// The broadcaster login.
-    pub broadcaster_user_login: types::UserName,
-    ///The broadcaster display name.
-    pub broadcaster_user_name: types::DisplayName,
-}
-
 /// Information about a channel’s Hype Train records.
 #[derive(PartialEq, Eq, Deserialize, Serialize, Debug, Clone)]
 #[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
@@ -156,38 +149,6 @@ pub struct HypeTrainRecord {
     pub total: u64,
     /// The time when the record was achieved.
     pub achieved_at: types::Timestamp,
-}
-
-/// Type of Hype Train event
-#[derive(PartialEq, Eq, Deserialize, Serialize, Debug, Clone)]
-#[non_exhaustive]
-#[serde(rename_all = "snake_case")]
-pub enum HypeTrainType {
-    /// A treasure train.
-    Treasure,
-    /// A golden Kappa train.
-    GoldenKappa,
-    /// A regular train.
-    Regular,
-    /// An unknown hype train type, contains the raw string provided by Twitch.
-    #[serde(untagged)]
-    Unknown(String),
-}
-
-/// Type of Hype Train event
-#[derive(PartialEq, Eq, Deserialize, Serialize, Debug, Clone)]
-#[non_exhaustive]
-#[serde(rename_all = "snake_case")]
-pub enum HypeTrainContributionType {
-    /// Cheering with bits
-    Bits,
-    /// Subscription activity like subscribing or gifting subscriptions.
-    Subscription,
-    /// Covers other contribution methods not listed.
-    Other,
-    /// An unknown contribution type, contains the raw string provided by Twitch.
-    #[serde(untagged)]
-    Unknown(String),
 }
 
 impl Request for GetHypeTrainStatusRequest<'_> {

--- a/src/helix/endpoints/hypetrain/mod.rs
+++ b/src/helix/endpoints/hypetrain/mod.rs
@@ -22,8 +22,13 @@ use std::borrow::Cow;
 
 pub mod get_hype_train_status;
 
+// Re-exported from common for backwards compatability
+#[doc(inline)]
+pub use crate::common::hypetrain::{
+    HypeTrainContributionType, HypeTrainType, SharedTrainParticipant,
+};
+
 #[doc(inline)]
 pub use get_hype_train_status::{
-    GetHypeTrainStatusRequest, HypeTrain, HypeTrainContributionType, HypeTrainRecord,
-    HypeTrainStatus, HypeTrainType, SharedTrainParticipant,
+    GetHypeTrainStatusRequest, HypeTrain, HypeTrainRecord, HypeTrainStatus,
 };


### PR DESCRIPTION
I went through the files and updated all the definitions for the hypetrain eventsubs and all references to them to match the current twitch API [documentation](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types/#channelhype_trainend).

This closes my [issue](https://github.com/twitch-rs/twitch_api/issues/534).