### PR TITLE
chore(eventsub): Add `id` for `stream.offline`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1677,9 +1677,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",

--- a/src/eventsub/stream/offline.rs
+++ b/src/eventsub/stream/offline.rs
@@ -36,6 +36,8 @@ impl EventSubscription for StreamOfflineV1 {
 #[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
 #[non_exhaustive]
 pub struct StreamOfflineV1Payload {
+    /// The id of the stream.
+    pub id: types::StreamId,
     /// The broadcaster’s user id.
     pub broadcaster_user_id: types::UserId,
     /// The broadcaster’s user login.
@@ -65,6 +67,7 @@ fn parse_payload() {
             }
         },
         "event": {
+            "id": "9001",
             "broadcaster_user_id": "1337",
             "broadcaster_user_login": "cool_user",
             "broadcaster_user_name": "Cool_User"

--- a/src/eventsub/stream/online.rs
+++ b/src/eventsub/stream/online.rs
@@ -43,6 +43,7 @@ pub struct StreamOnlineV1Payload {
     /// The broadcaster’s user display name.
     pub broadcaster_user_name: types::DisplayName,
     /// The id of the stream.
+    // FIXME: This should be types::StreamId
     pub id: String,
     /// The stream type. Valid values are: live, playlist, watch_party, premiere, rerun.
     #[serde(rename = "type")]


### PR DESCRIPTION
From the [changelog](https://dev.twitch.tv/docs/change-log/#2026-06-26):
> V1 of the [stream.offline](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types/#streamoffline) EventSub subscription type has been updated to include the `id` parameter in the event payload.